### PR TITLE
fix: remove null-guards on optional fields and add serialization tests

### DIFF
--- a/Com.Hopper.Hts.Airlines.sln
+++ b/Com.Hopper.Hts.Airlines.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Com.Hopper.Hts.Airlines", "src\Com.Hopper.Hts.Airlines\Com.Hopper.Hts.Airlines.csproj", "{48E9A5D3-6295-4012-AB0B-D54773FFFA1D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Com.Hopper.Hts.Airlines", "src\Com.Hopper.Hts.Airlines\Com.Hopper.Hts.Airlines.csproj", "{F0278D69-0DD8-4287-92FA-1CC74C654505}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Com.Hopper.Hts.Airlines.Test", "src\Com.Hopper.Hts.Airlines.Test\Com.Hopper.Hts.Airlines.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{48E9A5D3-6295-4012-AB0B-D54773FFFA1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{48E9A5D3-6295-4012-AB0B-D54773FFFA1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{48E9A5D3-6295-4012-AB0B-D54773FFFA1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{48E9A5D3-6295-4012-AB0B-D54773FFFA1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0278D69-0DD8-4287-92FA-1CC74C654505}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0278D69-0DD8-4287-92FA-1CC74C654505}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0278D69-0DD8-4287-92FA-1CC74C654505}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0278D69-0DD8-4287-92FA-1CC74C654505}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.1.16
+VERSION=0.1.17
 docker run --rm -v "${PWD}/:/local" -v "${PWD}/api/:/api" openapitools/openapi-generator-cli:v7.10.0 generate \
     -i https://airlines-api.hopper.com/airline/v1.1/docs/docs.yaml \
     -g csharp \

--- a/src/Com.Hopper.Hts.Airlines.Test/Serialization/DeviceSerializationTests.cs
+++ b/src/Com.Hopper.Hts.Airlines.Test/Serialization/DeviceSerializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using Com.Hopper.Hts.Airlines.Client;
 using Com.Hopper.Hts.Airlines.Model;
@@ -155,6 +156,116 @@ namespace Com.Hopper.Hts.Airlines.Test.Serialization
             Assert.Equal(Mobile.TypeEnum.Mobile, deserialized.Mobile.Type);
             Assert.Equal("light", deserialized.Mobile.UiTheme);
             Assert.Equal("1.0.0", deserialized.Mobile.ReleaseBuild);
+        }
+
+        /// <summary>
+        /// Verifies all nested type discriminator fields are present in serialized JSON:
+        /// device.type, platform.type, operating_system.type
+        /// </summary>
+        [Fact]
+        public void Serialize_NestedDevice_AllTypeDiscriminatorsPresent()
+        {
+            var device = new Device(new Mobile(
+                id: "discriminator-test",
+                type: Mobile.TypeEnum.Mobile,
+                platform: new Option<Platform?>(new Platform(new App(
+                    type: App.TypeEnum.App,
+                    varOperatingSystem: new Option<ModelOperatingSystem?>(new ModelOperatingSystem(new Android(
+                        type: Android.TypeEnum.Android,
+                        varVersion: new Option<string?>("15")
+                    )))
+                )))
+            ));
+
+            var options = new JsonSerializerOptions
+            {
+                Converters =
+                {
+                    new DeviceJsonConverter(),
+                    new MobileJsonConverter(),
+                    new PlatformJsonConverter(),
+                    new AppJsonConverter(),
+                    new ModelOperatingSystemJsonConverter(),
+                    new AndroidJsonConverter()
+                }
+            };
+
+            var json = JsonSerializer.Serialize(device, options);
+
+            Assert.Contains("\"type\":\"mobile\"", json);
+            Assert.Contains("\"type\":\"app\"", json);
+            Assert.Contains("\"type\":\"android\"", json);
+            Assert.Contains("\"operating_system\"", json);
+            Assert.Contains("\"version\":\"15\"", json);
+        }
+
+        /// <summary>
+        /// Verifies that ReleaseBuild can be omitted entirely (not a breaking change).
+        /// </summary>
+        [Fact]
+        public void Serialize_MobileDevice_ReleaseBuildOmitted_Succeeds()
+        {
+            var device = new Device(new Mobile(
+                id: "no-release-build",
+                type: Mobile.TypeEnum.Mobile
+            ));
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new DeviceJsonConverter() }
+            };
+
+            var json = JsonSerializer.Serialize(device, options);
+
+            Assert.Contains("\"id\":\"no-release-build\"", json);
+            Assert.Contains("\"type\":\"mobile\"", json);
+            Assert.DoesNotContain("release_build", json);
+        }
+
+        /// <summary>
+        /// Verifies that explicitly setting ReleaseBuild to null serializes
+        /// without throwing (the API accepts null for this field).
+        /// </summary>
+        [Fact]
+        public void Serialize_MobileDevice_ReleaseBuildExplicitNull_Succeeds()
+        {
+            var device = new Device(new Mobile(
+                id: "null-release-build",
+                type: Mobile.TypeEnum.Mobile,
+                releaseBuild: new Option<string?>(null)
+            ));
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new DeviceJsonConverter() }
+            };
+
+            var json = JsonSerializer.Serialize(device, options);
+
+            Assert.Contains("\"id\":\"null-release-build\"", json);
+            Assert.Contains("\"type\":\"mobile\"", json);
+        }
+
+        /// <summary>
+        /// Verifies that setting ReleaseBuild to a value works correctly.
+        /// </summary>
+        [Fact]
+        public void Serialize_MobileDevice_ReleaseBuildWithValue_Succeeds()
+        {
+            var device = new Device(new Mobile(
+                id: "with-release-build",
+                type: Mobile.TypeEnum.Mobile,
+                releaseBuild: new Option<string?>("3.4.1")
+            ));
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new DeviceJsonConverter() }
+            };
+
+            var json = JsonSerializer.Serialize(device, options);
+
+            Assert.Contains("\"release_build\":\"3.4.1\"", json);
         }
     }
 }

--- a/src/Com.Hopper.Hts.Airlines/Client/ClientUtils.cs
+++ b/src/Com.Hopper.Hts.Airlines/Client/ClientUtils.cs
@@ -158,8 +158,8 @@ namespace Com.Hopper.Hts.Airlines.Client
                 return AncillaryTypeValueConverter.ToJsonValue(ancillaryType);
             if (obj is Android.TypeEnum androidTypeEnum)
                 return Android.TypeEnumToJsonValue(androidTypeEnum);
-            if (obj is Api.TypeEnum apiTypeEnum)
-                return Api.TypeEnumToJsonValue(apiTypeEnum);
+            if (obj is Com.Hopper.Hts.Airlines.Model.Api.TypeEnum apiTypeEnum)
+                return Com.Hopper.Hts.Airlines.Model.Api.TypeEnumToJsonValue(apiTypeEnum);
             if (obj is App.TypeEnum appTypeEnum)
                 return App.TypeEnumToJsonValue(appTypeEnum);
             if (obj is BookingConfirmed.TypeEnum bookingConfirmedTypeEnum)

--- a/src/Com.Hopper.Hts.Airlines/Client/ClientUtils.cs
+++ b/src/Com.Hopper.Hts.Airlines/Client/ClientUtils.cs
@@ -158,8 +158,8 @@ namespace Com.Hopper.Hts.Airlines.Client
                 return AncillaryTypeValueConverter.ToJsonValue(ancillaryType);
             if (obj is Android.TypeEnum androidTypeEnum)
                 return Android.TypeEnumToJsonValue(androidTypeEnum);
-            if (obj is Model.Api.TypeEnum apiTypeEnum)
-                return Model.Api.TypeEnumToJsonValue(apiTypeEnum);
+            if (obj is Api.TypeEnum apiTypeEnum)
+                return Api.TypeEnumToJsonValue(apiTypeEnum);
             if (obj is App.TypeEnum appTypeEnum)
                 return App.TypeEnumToJsonValue(appTypeEnum);
             if (obj is BookingConfirmed.TypeEnum bookingConfirmedTypeEnum)

--- a/src/Com.Hopper.Hts.Airlines/Com.Hopper.Hts.Airlines.csproj
+++ b/src/Com.Hopper.Hts.Airlines/Com.Hopper.Hts.Airlines.csproj
@@ -12,7 +12,7 @@
     <Description>A library generated from a OpenAPI doc</Description>
     <Copyright>No Copyright</Copyright>
     <RootNamespace>Com.Hopper.Hts.Airlines</RootNamespace>
-    <Version>0.1.16</Version>
+    <Version>0.1.17</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Com.Hopper.Hts.Airlines.xml</DocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/GIT_USER_ID/GIT_REPO_ID.git</RepositoryUrl>

--- a/src/Com.Hopper.Hts.Airlines/Model/Ancillary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Ancillary.cs
@@ -183,12 +183,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Ancillary.");
 
-            if (passengerReference.IsSet && passengerReference.Value == null)
-                throw new ArgumentNullException(nameof(passengerReference), "Property is not nullable for class Ancillary.");
-
-            if (covered.IsSet && covered.Value == null)
-                throw new ArgumentNullException(nameof(covered), "Property is not nullable for class Ancillary.");
-
             return new Ancillary(totalPrice.Value!, type.Value!.Value!, passengerReference, covered);
         }
 
@@ -218,9 +212,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (ancillary.TotalPrice == null)
                 throw new ArgumentNullException(nameof(ancillary.TotalPrice), "Property is required for class Ancillary.");
-
-            if (ancillary.PassengerReferenceOption.IsSet && ancillary.PassengerReference == null)
-                throw new ArgumentNullException(nameof(ancillary.PassengerReference), "Property is required for class Ancillary.");
 
             writer.WriteString("total_price", ancillary.TotalPrice);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Android.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Android.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Android.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Android.");
-
             return new Android(type.Value!.Value!, varVersion);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Android android, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (android.VarVersionOption.IsSet && android.VarVersion == null)
-                throw new ArgumentNullException(nameof(android.VarVersion), "Property is required for class Android.");
-
             var typeRawValue = Android.TypeEnumToJsonValue(android.Type);
             writer.WriteString("type", typeRawValue);
             if (android.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/App.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/App.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class App.");
 
-            if (varOperatingSystem.IsSet && varOperatingSystem.Value == null)
-                throw new ArgumentNullException(nameof(varOperatingSystem), "Property is not nullable for class App.");
-
             return new App(type.Value!.Value!, varOperatingSystem);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, App app, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (app.VarOperatingSystemOption.IsSet && app.VarOperatingSystem == null)
-                throw new ArgumentNullException(nameof(app.VarOperatingSystem), "Property is required for class App.");
-
             var typeRawValue = App.TypeEnumToJsonValue(app.Type);
             writer.WriteString("type", typeRawValue);
             if (app.VarOperatingSystemOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/BookingConfirmed.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/BookingConfirmed.cs
@@ -239,12 +239,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class BookingConfirmed.");
 
-            if (cfarContractId.IsSet && cfarContractId.Value == null)
-                throw new ArgumentNullException(nameof(cfarContractId), "Property is not nullable for class BookingConfirmed.");
-
-            if (dgContractId.IsSet && dgContractId.Value == null)
-                throw new ArgumentNullException(nameof(dgContractId), "Property is not nullable for class BookingConfirmed.");
-
             return new BookingConfirmed(occurredDateTime.Value!.Value!, type.Value!.Value!, cfarContractId, dgContractId);
         }
 
@@ -272,12 +266,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, BookingConfirmed bookingConfirmed, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (bookingConfirmed.CfarContractIdOption.IsSet && bookingConfirmed.CfarContractId == null)
-                throw new ArgumentNullException(nameof(bookingConfirmed.CfarContractId), "Property is required for class BookingConfirmed.");
-
-            if (bookingConfirmed.DgContractIdOption.IsSet && bookingConfirmed.DgContractId == null)
-                throw new ArgumentNullException(nameof(bookingConfirmed.DgContractId), "Property is required for class BookingConfirmed.");
-
             writer.WriteString("occurred_date_time", bookingConfirmed.OccurredDateTime.ToString(OccurredDateTimeFormat));
 
             var typeRawValue = BookingConfirmed.TypeEnumToJsonValue(bookingConfirmed.Type);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarContract.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarContract.cs
@@ -445,15 +445,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class CfarContract.");
 
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class CfarContract.");
-
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class CfarContract.");
-
-            if (exerciseUrl.IsSet && exerciseUrl.Value == null)
-                throw new ArgumentNullException(nameof(exerciseUrl), "Property is not nullable for class CfarContract.");
-
             return new CfarContract(id.Value!, reference.Value!, offers.Value!, itinerary.Value!, coveragePercentage.Value!, coverage.Value!, premium.Value!, currency.Value!, taxesTotal.Value!, createdDateTime.Value!.Value!, expiryDateTime.Value!.Value!, status.Value!.Value!, extAttributes.Value!, taxes, pnrReference, exerciseUrl);
         }
 
@@ -510,15 +501,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarContract.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(cfarContract.ExtAttributes), "Property is required for class CfarContract.");
-
-            if (cfarContract.TaxesOption.IsSet && cfarContract.Taxes == null)
-                throw new ArgumentNullException(nameof(cfarContract.Taxes), "Property is required for class CfarContract.");
-
-            if (cfarContract.PnrReferenceOption.IsSet && cfarContract.PnrReference == null)
-                throw new ArgumentNullException(nameof(cfarContract.PnrReference), "Property is required for class CfarContract.");
-
-            if (cfarContract.ExerciseUrlOption.IsSet && cfarContract.ExerciseUrl == null)
-                throw new ArgumentNullException(nameof(cfarContract.ExerciseUrl), "Property is required for class CfarContract.");
 
             writer.WriteString("id", cfarContract.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarContractExercise.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarContractExercise.cs
@@ -294,15 +294,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (redirectionToken.IsSet && redirectionToken.Value == null)
                 throw new ArgumentNullException(nameof(redirectionToken), "Property is not nullable for class CfarContractExercise.");
 
-            if (ftcRefundAllowance.IsSet && ftcRefundAllowance.Value == null)
-                throw new ArgumentNullException(nameof(ftcRefundAllowance), "Property is not nullable for class CfarContractExercise.");
-
-            if (currency.IsSet && currency.Value == null)
-                throw new ArgumentNullException(nameof(currency), "Property is not nullable for class CfarContractExercise.");
-
-            if (redirectionUrl.IsSet && redirectionUrl.Value == null)
-                throw new ArgumentNullException(nameof(redirectionUrl), "Property is not nullable for class CfarContractExercise.");
-
             return new CfarContractExercise(id.Value!, contractId.Value!, exerciseInitiatedDateTime.Value!.Value!, cashRefundAllowance.Value!, extAttributes.Value!, redirectionToken.Value!.Value!, ftcRefundAllowance, currency, redirectionUrl);
         }
 
@@ -341,15 +332,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarContractExercise.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(cfarContractExercise.ExtAttributes), "Property is required for class CfarContractExercise.");
-
-            if (cfarContractExercise.FtcRefundAllowanceOption.IsSet && cfarContractExercise.FtcRefundAllowance == null)
-                throw new ArgumentNullException(nameof(cfarContractExercise.FtcRefundAllowance), "Property is required for class CfarContractExercise.");
-
-            if (cfarContractExercise.CurrencyOption.IsSet && cfarContractExercise.Currency == null)
-                throw new ArgumentNullException(nameof(cfarContractExercise.Currency), "Property is required for class CfarContractExercise.");
-
-            if (cfarContractExercise.RedirectionUrlOption.IsSet && cfarContractExercise.RedirectionUrl == null)
-                throw new ArgumentNullException(nameof(cfarContractExercise.RedirectionUrl), "Property is required for class CfarContractExercise.");
 
             writer.WriteString("id", cfarContractExercise.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExerciseItinerary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExerciseItinerary.cs
@@ -250,24 +250,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (slices.IsSet && slices.Value == null)
                 throw new ArgumentNullException(nameof(slices), "Property is not nullable for class CfarCreateExerciseItinerary.");
 
-            if (passengerPricing.IsSet && passengerPricing.Value == null)
-                throw new ArgumentNullException(nameof(passengerPricing), "Property is not nullable for class CfarCreateExerciseItinerary.");
-
-            if (currency.IsSet && currency.Value == null)
-                throw new ArgumentNullException(nameof(currency), "Property is not nullable for class CfarCreateExerciseItinerary.");
-
-            if (ancillaries.IsSet && ancillaries.Value == null)
-                throw new ArgumentNullException(nameof(ancillaries), "Property is not nullable for class CfarCreateExerciseItinerary.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class CfarCreateExerciseItinerary.");
-
-            if (passengers.IsSet && passengers.Value == null)
-                throw new ArgumentNullException(nameof(passengers), "Property is not nullable for class CfarCreateExerciseItinerary.");
-
-            if (fareRules.IsSet && fareRules.Value == null)
-                throw new ArgumentNullException(nameof(fareRules), "Property is not nullable for class CfarCreateExerciseItinerary.");
-
             return new CfarCreateExerciseItinerary(slices.Value!, passengerPricing, currency, ancillaries, totalPrice, passengers, fareRules);
         }
 
@@ -297,24 +279,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (cfarCreateExerciseItinerary.Slices == null)
                 throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.Slices), "Property is required for class CfarCreateExerciseItinerary.");
-
-            if (cfarCreateExerciseItinerary.PassengerPricingOption.IsSet && cfarCreateExerciseItinerary.PassengerPricing == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.PassengerPricing), "Property is required for class CfarCreateExerciseItinerary.");
-
-            if (cfarCreateExerciseItinerary.CurrencyOption.IsSet && cfarCreateExerciseItinerary.Currency == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.Currency), "Property is required for class CfarCreateExerciseItinerary.");
-
-            if (cfarCreateExerciseItinerary.AncillariesOption.IsSet && cfarCreateExerciseItinerary.Ancillaries == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.Ancillaries), "Property is required for class CfarCreateExerciseItinerary.");
-
-            if (cfarCreateExerciseItinerary.TotalPriceOption.IsSet && cfarCreateExerciseItinerary.TotalPrice == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.TotalPrice), "Property is required for class CfarCreateExerciseItinerary.");
-
-            if (cfarCreateExerciseItinerary.PassengersOption.IsSet && cfarCreateExerciseItinerary.Passengers == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.Passengers), "Property is required for class CfarCreateExerciseItinerary.");
-
-            if (cfarCreateExerciseItinerary.FareRulesOption.IsSet && cfarCreateExerciseItinerary.FareRules == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerary.FareRules), "Property is required for class CfarCreateExerciseItinerary.");
 
             writer.WritePropertyName("slices");
             JsonSerializer.Serialize(writer, cfarCreateExerciseItinerary.Slices, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExerciseItinerarySlice.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExerciseItinerarySlice.cs
@@ -250,24 +250,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (segments.IsSet && segments.Value == null)
                 throw new ArgumentNullException(nameof(segments), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
 
-            if (passengerPricing.IsSet && passengerPricing.Value == null)
-                throw new ArgumentNullException(nameof(passengerPricing), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
-
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
-
-            if (fareBasis.IsSet && fareBasis.Value == null)
-                throw new ArgumentNullException(nameof(fareBasis), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
-
-            if (fareRules.IsSet && fareRules.Value == null)
-                throw new ArgumentNullException(nameof(fareRules), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
-
-            if (otherFares.IsSet && otherFares.Value == null)
-                throw new ArgumentNullException(nameof(otherFares), "Property is not nullable for class CfarCreateExerciseItinerarySlice.");
-
             return new CfarCreateExerciseItinerarySlice(segments.Value!, passengerPricing, totalPrice, fareBrand, fareBasis, fareRules, otherFares);
         }
 
@@ -297,24 +279,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (cfarCreateExerciseItinerarySlice.Segments == null)
                 throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.Segments), "Property is required for class CfarCreateExerciseItinerarySlice.");
-
-            if (cfarCreateExerciseItinerarySlice.PassengerPricingOption.IsSet && cfarCreateExerciseItinerarySlice.PassengerPricing == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.PassengerPricing), "Property is required for class CfarCreateExerciseItinerarySlice.");
-
-            if (cfarCreateExerciseItinerarySlice.TotalPriceOption.IsSet && cfarCreateExerciseItinerarySlice.TotalPrice == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.TotalPrice), "Property is required for class CfarCreateExerciseItinerarySlice.");
-
-            if (cfarCreateExerciseItinerarySlice.FareBrandOption.IsSet && cfarCreateExerciseItinerarySlice.FareBrand == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.FareBrand), "Property is required for class CfarCreateExerciseItinerarySlice.");
-
-            if (cfarCreateExerciseItinerarySlice.FareBasisOption.IsSet && cfarCreateExerciseItinerarySlice.FareBasis == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.FareBasis), "Property is required for class CfarCreateExerciseItinerarySlice.");
-
-            if (cfarCreateExerciseItinerarySlice.FareRulesOption.IsSet && cfarCreateExerciseItinerarySlice.FareRules == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.FareRules), "Property is required for class CfarCreateExerciseItinerarySlice.");
-
-            if (cfarCreateExerciseItinerarySlice.OtherFaresOption.IsSet && cfarCreateExerciseItinerarySlice.OtherFares == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseItinerarySlice.OtherFares), "Property is required for class CfarCreateExerciseItinerarySlice.");
 
             writer.WritePropertyName("segments");
             JsonSerializer.Serialize(writer, cfarCreateExerciseItinerarySlice.Segments, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExercisePassengerPricing.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExercisePassengerPricing.cs
@@ -161,12 +161,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (passengerCount.IsSet && passengerCount.Value == null)
                 throw new ArgumentNullException(nameof(passengerCount), "Property is not nullable for class CfarCreateExercisePassengerPricing.");
 
-            if (individualPrice.IsSet && individualPrice.Value == null)
-                throw new ArgumentNullException(nameof(individualPrice), "Property is not nullable for class CfarCreateExercisePassengerPricing.");
-
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class CfarCreateExercisePassengerPricing.");
-
             return new CfarCreateExercisePassengerPricing(passengerCount.Value!, individualPrice, taxes);
         }
 
@@ -196,12 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (cfarCreateExercisePassengerPricing.PassengerCount == null)
                 throw new ArgumentNullException(nameof(cfarCreateExercisePassengerPricing.PassengerCount), "Property is required for class CfarCreateExercisePassengerPricing.");
-
-            if (cfarCreateExercisePassengerPricing.IndividualPriceOption.IsSet && cfarCreateExercisePassengerPricing.IndividualPrice == null)
-                throw new ArgumentNullException(nameof(cfarCreateExercisePassengerPricing.IndividualPrice), "Property is required for class CfarCreateExercisePassengerPricing.");
-
-            if (cfarCreateExercisePassengerPricing.TaxesOption.IsSet && cfarCreateExercisePassengerPricing.Taxes == null)
-                throw new ArgumentNullException(nameof(cfarCreateExercisePassengerPricing.Taxes), "Property is required for class CfarCreateExercisePassengerPricing.");
 
             writer.WritePropertyName("passenger_count");
             JsonSerializer.Serialize(writer, cfarCreateExercisePassengerPricing.PassengerCount, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExerciseSliceSegment.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarCreateExerciseSliceSegment.cs
@@ -267,15 +267,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (flightNumber.IsSet && flightNumber.Value == null)
                 throw new ArgumentNullException(nameof(flightNumber), "Property is not nullable for class CfarCreateExerciseSliceSegment.");
 
-            if (validatingCarrierCode.IsSet && validatingCarrierCode.Value == null)
-                throw new ArgumentNullException(nameof(validatingCarrierCode), "Property is not nullable for class CfarCreateExerciseSliceSegment.");
-
-            if (fareClass.IsSet && fareClass.Value == null)
-                throw new ArgumentNullException(nameof(fareClass), "Property is not nullable for class CfarCreateExerciseSliceSegment.");
-
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class CfarCreateExerciseSliceSegment.");
-
             return new CfarCreateExerciseSliceSegment(originAirport.Value!, destinationAirport.Value!, departureDateTime.Value!, arrivalDateTime.Value!, flightNumber.Value!, validatingCarrierCode, fareClass, fareBrand);
         }
 
@@ -317,12 +308,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarCreateExerciseSliceSegment.FlightNumber == null)
                 throw new ArgumentNullException(nameof(cfarCreateExerciseSliceSegment.FlightNumber), "Property is required for class CfarCreateExerciseSliceSegment.");
-
-            if (cfarCreateExerciseSliceSegment.ValidatingCarrierCodeOption.IsSet && cfarCreateExerciseSliceSegment.ValidatingCarrierCode == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseSliceSegment.ValidatingCarrierCode), "Property is required for class CfarCreateExerciseSliceSegment.");
-
-            if (cfarCreateExerciseSliceSegment.FareBrandOption.IsSet && cfarCreateExerciseSliceSegment.FareBrand == null)
-                throw new ArgumentNullException(nameof(cfarCreateExerciseSliceSegment.FareBrand), "Property is required for class CfarCreateExerciseSliceSegment.");
 
             writer.WriteString("origin_airport", cfarCreateExerciseSliceSegment.OriginAirport);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarItinerary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarItinerary.cs
@@ -270,21 +270,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (slices.IsSet && slices.Value == null)
                 throw new ArgumentNullException(nameof(slices), "Property is not nullable for class CfarItinerary.");
 
-            if (ancillaries.IsSet && ancillaries.Value == null)
-                throw new ArgumentNullException(nameof(ancillaries), "Property is not nullable for class CfarItinerary.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class CfarItinerary.");
-
-            if (passengers.IsSet && passengers.Value == null)
-                throw new ArgumentNullException(nameof(passengers), "Property is not nullable for class CfarItinerary.");
-
-            if (fareRules.IsSet && fareRules.Value == null)
-                throw new ArgumentNullException(nameof(fareRules), "Property is not nullable for class CfarItinerary.");
-
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class CfarItinerary.");
-
             return new CfarItinerary(passengerPricing.Value!, currency.Value!, slices.Value!, ancillaries, totalPrice, passengers, fareRules, taxes);
         }
 
@@ -320,21 +305,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarItinerary.Slices == null)
                 throw new ArgumentNullException(nameof(cfarItinerary.Slices), "Property is required for class CfarItinerary.");
-
-            if (cfarItinerary.AncillariesOption.IsSet && cfarItinerary.Ancillaries == null)
-                throw new ArgumentNullException(nameof(cfarItinerary.Ancillaries), "Property is required for class CfarItinerary.");
-
-            if (cfarItinerary.TotalPriceOption.IsSet && cfarItinerary.TotalPrice == null)
-                throw new ArgumentNullException(nameof(cfarItinerary.TotalPrice), "Property is required for class CfarItinerary.");
-
-            if (cfarItinerary.PassengersOption.IsSet && cfarItinerary.Passengers == null)
-                throw new ArgumentNullException(nameof(cfarItinerary.Passengers), "Property is required for class CfarItinerary.");
-
-            if (cfarItinerary.FareRulesOption.IsSet && cfarItinerary.FareRules == null)
-                throw new ArgumentNullException(nameof(cfarItinerary.FareRules), "Property is required for class CfarItinerary.");
-
-            if (cfarItinerary.TaxesOption.IsSet && cfarItinerary.Taxes == null)
-                throw new ArgumentNullException(nameof(cfarItinerary.Taxes), "Property is required for class CfarItinerary.");
 
             writer.WritePropertyName("passenger_pricing");
             JsonSerializer.Serialize(writer, cfarItinerary.PassengerPricing, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarItinerarySlice.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarItinerarySlice.cs
@@ -250,24 +250,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (segments.IsSet && segments.Value == null)
                 throw new ArgumentNullException(nameof(segments), "Property is not nullable for class CfarItinerarySlice.");
 
-            if (passengerPricing.IsSet && passengerPricing.Value == null)
-                throw new ArgumentNullException(nameof(passengerPricing), "Property is not nullable for class CfarItinerarySlice.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class CfarItinerarySlice.");
-
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class CfarItinerarySlice.");
-
-            if (fareBasis.IsSet && fareBasis.Value == null)
-                throw new ArgumentNullException(nameof(fareBasis), "Property is not nullable for class CfarItinerarySlice.");
-
-            if (fareRules.IsSet && fareRules.Value == null)
-                throw new ArgumentNullException(nameof(fareRules), "Property is not nullable for class CfarItinerarySlice.");
-
-            if (otherFares.IsSet && otherFares.Value == null)
-                throw new ArgumentNullException(nameof(otherFares), "Property is not nullable for class CfarItinerarySlice.");
-
             return new CfarItinerarySlice(segments.Value!, passengerPricing, totalPrice, fareBrand, fareBasis, fareRules, otherFares);
         }
 
@@ -297,24 +279,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (cfarItinerarySlice.Segments == null)
                 throw new ArgumentNullException(nameof(cfarItinerarySlice.Segments), "Property is required for class CfarItinerarySlice.");
-
-            if (cfarItinerarySlice.PassengerPricingOption.IsSet && cfarItinerarySlice.PassengerPricing == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySlice.PassengerPricing), "Property is required for class CfarItinerarySlice.");
-
-            if (cfarItinerarySlice.TotalPriceOption.IsSet && cfarItinerarySlice.TotalPrice == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySlice.TotalPrice), "Property is required for class CfarItinerarySlice.");
-
-            if (cfarItinerarySlice.FareBrandOption.IsSet && cfarItinerarySlice.FareBrand == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySlice.FareBrand), "Property is required for class CfarItinerarySlice.");
-
-            if (cfarItinerarySlice.FareBasisOption.IsSet && cfarItinerarySlice.FareBasis == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySlice.FareBasis), "Property is required for class CfarItinerarySlice.");
-
-            if (cfarItinerarySlice.FareRulesOption.IsSet && cfarItinerarySlice.FareRules == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySlice.FareRules), "Property is required for class CfarItinerarySlice.");
-
-            if (cfarItinerarySlice.OtherFaresOption.IsSet && cfarItinerarySlice.OtherFares == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySlice.OtherFares), "Property is required for class CfarItinerarySlice.");
 
             writer.WritePropertyName("segments");
             JsonSerializer.Serialize(writer, cfarItinerarySlice.Segments, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarItinerarySliceSegment.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarItinerarySliceSegment.cs
@@ -265,9 +265,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (fareClass.IsSet && fareClass.Value == null)
                 throw new ArgumentNullException(nameof(fareClass), "Property is not nullable for class CfarItinerarySliceSegment.");
 
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class CfarItinerarySliceSegment.");
-
             return new CfarItinerarySliceSegment(originAirport.Value!, destinationAirport.Value!, departureDateTime.Value!, arrivalDateTime.Value!, flightNumber.Value!, validatingCarrierCode.Value!, fareClass.Value!.Value!, fareBrand);
         }
 
@@ -312,9 +309,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarItinerarySliceSegment.ValidatingCarrierCode == null)
                 throw new ArgumentNullException(nameof(cfarItinerarySliceSegment.ValidatingCarrierCode), "Property is required for class CfarItinerarySliceSegment.");
-
-            if (cfarItinerarySliceSegment.FareBrandOption.IsSet && cfarItinerarySliceSegment.FareBrand == null)
-                throw new ArgumentNullException(nameof(cfarItinerarySliceSegment.FareBrand), "Property is required for class CfarItinerarySliceSegment.");
 
             writer.WriteString("origin_airport", cfarItinerarySliceSegment.OriginAirport);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarOffer.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarOffer.cs
@@ -528,27 +528,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (experiments.IsSet && experiments.Value == null)
                 throw new ArgumentNullException(nameof(experiments), "Property is not nullable for class CfarOffer.");
 
-            if (coverageExtension.IsSet && coverageExtension.Value == null)
-                throw new ArgumentNullException(nameof(coverageExtension), "Property is not nullable for class CfarOffer.");
-
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class CfarOffer.");
-
-            if (entryPoint.IsSet && entryPoint.Value == null)
-                throw new ArgumentNullException(nameof(entryPoint), "Property is not nullable for class CfarOffer.");
-
-            if (termsConditionsUrl.IsSet && termsConditionsUrl.Value == null)
-                throw new ArgumentNullException(nameof(termsConditionsUrl), "Property is not nullable for class CfarOffer.");
-
-            if (faqUrl.IsSet && faqUrl.Value == null)
-                throw new ArgumentNullException(nameof(faqUrl), "Property is not nullable for class CfarOffer.");
-
-            if (merchandisingUrl.IsSet && merchandisingUrl.Value == null)
-                throw new ArgumentNullException(nameof(merchandisingUrl), "Property is not nullable for class CfarOffer.");
-
-            if (merchandisingUrlWebComponent.IsSet && merchandisingUrlWebComponent.Value == null)
-                throw new ArgumentNullException(nameof(merchandisingUrlWebComponent), "Property is not nullable for class CfarOffer.");
-
             return new CfarOffer(id.Value!, premium.Value!, coverage.Value!, coveragePercentage.Value!, currency.Value!, taxesTotal.Value!, requestType.Value!.Value!, contractExpiryDateTime.Value!.Value!, createdDateTime.Value!.Value!, itinerary.Value!, contents.Value!, extAttributes.Value!, experiments.Value!, coverageExtension, taxes, entryPoint, termsConditionsUrl, faqUrl, merchandisingUrl, merchandisingUrlWebComponent);
         }
 
@@ -605,27 +584,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarOffer.Experiments == null)
                 throw new ArgumentNullException(nameof(cfarOffer.Experiments), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.CoverageExtensionOption.IsSet && cfarOffer.CoverageExtension == null)
-                throw new ArgumentNullException(nameof(cfarOffer.CoverageExtension), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.TaxesOption.IsSet && cfarOffer.Taxes == null)
-                throw new ArgumentNullException(nameof(cfarOffer.Taxes), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.EntryPointOption.IsSet && cfarOffer.EntryPoint == null)
-                throw new ArgumentNullException(nameof(cfarOffer.EntryPoint), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.TermsConditionsUrlOption.IsSet && cfarOffer.TermsConditionsUrl == null)
-                throw new ArgumentNullException(nameof(cfarOffer.TermsConditionsUrl), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.FaqUrlOption.IsSet && cfarOffer.FaqUrl == null)
-                throw new ArgumentNullException(nameof(cfarOffer.FaqUrl), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.MerchandisingUrlOption.IsSet && cfarOffer.MerchandisingUrl == null)
-                throw new ArgumentNullException(nameof(cfarOffer.MerchandisingUrl), "Property is required for class CfarOffer.");
-
-            if (cfarOffer.MerchandisingUrlWebComponentOption.IsSet && cfarOffer.MerchandisingUrlWebComponent == null)
-                throw new ArgumentNullException(nameof(cfarOffer.MerchandisingUrlWebComponent), "Property is required for class CfarOffer.");
 
             writer.WriteString("id", cfarOffer.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarOfferItinerary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarOfferItinerary.cs
@@ -248,18 +248,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (slices.IsSet && slices.Value == null)
                 throw new ArgumentNullException(nameof(slices), "Property is not nullable for class CfarOfferItinerary.");
 
-            if (ancillaries.IsSet && ancillaries.Value == null)
-                throw new ArgumentNullException(nameof(ancillaries), "Property is not nullable for class CfarOfferItinerary.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class CfarOfferItinerary.");
-
-            if (passengers.IsSet && passengers.Value == null)
-                throw new ArgumentNullException(nameof(passengers), "Property is not nullable for class CfarOfferItinerary.");
-
-            if (fareRules.IsSet && fareRules.Value == null)
-                throw new ArgumentNullException(nameof(fareRules), "Property is not nullable for class CfarOfferItinerary.");
-
             return new CfarOfferItinerary(passengerPricing.Value!, currency.Value!, slices.Value!, ancillaries, totalPrice, passengers, fareRules);
         }
 
@@ -295,18 +283,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarOfferItinerary.Slices == null)
                 throw new ArgumentNullException(nameof(cfarOfferItinerary.Slices), "Property is required for class CfarOfferItinerary.");
-
-            if (cfarOfferItinerary.AncillariesOption.IsSet && cfarOfferItinerary.Ancillaries == null)
-                throw new ArgumentNullException(nameof(cfarOfferItinerary.Ancillaries), "Property is required for class CfarOfferItinerary.");
-
-            if (cfarOfferItinerary.TotalPriceOption.IsSet && cfarOfferItinerary.TotalPrice == null)
-                throw new ArgumentNullException(nameof(cfarOfferItinerary.TotalPrice), "Property is required for class CfarOfferItinerary.");
-
-            if (cfarOfferItinerary.PassengersOption.IsSet && cfarOfferItinerary.Passengers == null)
-                throw new ArgumentNullException(nameof(cfarOfferItinerary.Passengers), "Property is required for class CfarOfferItinerary.");
-
-            if (cfarOfferItinerary.FareRulesOption.IsSet && cfarOfferItinerary.FareRules == null)
-                throw new ArgumentNullException(nameof(cfarOfferItinerary.FareRules), "Property is required for class CfarOfferItinerary.");
 
             writer.WritePropertyName("passenger_pricing");
             JsonSerializer.Serialize(writer, cfarOfferItinerary.PassengerPricing, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarPassenger.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarPassenger.cs
@@ -183,12 +183,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (passengerType.IsSet && passengerType.Value == null)
                 throw new ArgumentNullException(nameof(passengerType), "Property is not nullable for class CfarPassenger.");
 
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class CfarPassenger.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class CfarPassenger.");
-
             return new CfarPassenger(passengerReference.Value!, passengerType.Value!.Value!, firstName, lastName);
         }
 
@@ -218,12 +212,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (cfarPassenger.PassengerReference == null)
                 throw new ArgumentNullException(nameof(cfarPassenger.PassengerReference), "Property is required for class CfarPassenger.");
-
-            if (cfarPassenger.FirstNameOption.IsSet && cfarPassenger.FirstName == null)
-                throw new ArgumentNullException(nameof(cfarPassenger.FirstName), "Property is required for class CfarPassenger.");
-
-            if (cfarPassenger.LastNameOption.IsSet && cfarPassenger.LastName == null)
-                throw new ArgumentNullException(nameof(cfarPassenger.LastName), "Property is required for class CfarPassenger.");
 
             writer.WriteString("passenger_reference", cfarPassenger.PassengerReference);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CfarTax.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CfarTax.cs
@@ -204,9 +204,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (estimated.IsSet && estimated.Value == null)
                 throw new ArgumentNullException(nameof(estimated), "Property is not nullable for class CfarTax.");
 
-            if (registrationNumber.IsSet && registrationNumber.Value == null)
-                throw new ArgumentNullException(nameof(registrationNumber), "Property is not nullable for class CfarTax.");
-
             return new CfarTax(name.Value!, rate.Value!, amount.Value!, estimated.Value!.Value!, registrationNumber);
         }
 
@@ -242,9 +239,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (cfarTax.Amount == null)
                 throw new ArgumentNullException(nameof(cfarTax.Amount), "Property is required for class CfarTax.");
-
-            if (cfarTax.RegistrationNumberOption.IsSet && cfarTax.RegistrationNumber == null)
-                throw new ArgumentNullException(nameof(cfarTax.RegistrationNumber), "Property is required for class CfarTax.");
 
             writer.WriteString("name", cfarTax.Name);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Chrome.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Chrome.cs
@@ -190,9 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Chrome.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Chrome.");
-
             return new Chrome(type.Value!.Value!, varVersion);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Chrome chrome, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (chrome.VarVersionOption.IsSet && chrome.VarVersion == null)
-                throw new ArgumentNullException(nameof(chrome.VarVersion), "Property is required for class Chrome.");
-
             var typeRawValue = Chrome.TypeEnumToJsonValue(chrome.Type);
             writer.WriteString("type", typeRawValue);
             if (chrome.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/ChromeOs.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/ChromeOs.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class ChromeOs.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class ChromeOs.");
-
             return new ChromeOs(type.Value!.Value!, varVersion);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, ChromeOs chromeOs, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (chromeOs.VarVersionOption.IsSet && chromeOs.VarVersion == null)
-                throw new ArgumentNullException(nameof(chromeOs.VarVersion), "Property is required for class ChromeOs.");
-
             var typeRawValue = ChromeOs.TypeEnumToJsonValue(chromeOs.Type);
             writer.WriteString("type", typeRawValue);
             if (chromeOs.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateAirlineCfarSessionRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateAirlineCfarSessionRequest.cs
@@ -224,18 +224,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (language.IsSet && language.Value == null)
                 throw new ArgumentNullException(nameof(language), "Property is not nullable for class CreateAirlineCfarSessionRequest.");
 
-            if (userInfo.IsSet && userInfo.Value == null)
-                throw new ArgumentNullException(nameof(userInfo), "Property is not nullable for class CreateAirlineCfarSessionRequest.");
-
-            if (device.IsSet && device.Value == null)
-                throw new ArgumentNullException(nameof(device), "Property is not nullable for class CreateAirlineCfarSessionRequest.");
-
-            if (sessionId.IsSet && sessionId.Value == null)
-                throw new ArgumentNullException(nameof(sessionId), "Property is not nullable for class CreateAirlineCfarSessionRequest.");
-
-            if (channel.IsSet && channel.Value == null)
-                throw new ArgumentNullException(nameof(channel), "Property is not nullable for class CreateAirlineCfarSessionRequest.");
-
             return new CreateAirlineCfarSessionRequest(pointOfSale.Value!, language.Value!, userInfo, device, sessionId, channel);
         }
 
@@ -268,18 +256,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createAirlineCfarSessionRequest.Language == null)
                 throw new ArgumentNullException(nameof(createAirlineCfarSessionRequest.Language), "Property is required for class CreateAirlineCfarSessionRequest.");
-
-            if (createAirlineCfarSessionRequest.UserInfoOption.IsSet && createAirlineCfarSessionRequest.UserInfo == null)
-                throw new ArgumentNullException(nameof(createAirlineCfarSessionRequest.UserInfo), "Property is required for class CreateAirlineCfarSessionRequest.");
-
-            if (createAirlineCfarSessionRequest.DeviceOption.IsSet && createAirlineCfarSessionRequest.Device == null)
-                throw new ArgumentNullException(nameof(createAirlineCfarSessionRequest.Device), "Property is required for class CreateAirlineCfarSessionRequest.");
-
-            if (createAirlineCfarSessionRequest.SessionIdOption.IsSet && createAirlineCfarSessionRequest.SessionId == null)
-                throw new ArgumentNullException(nameof(createAirlineCfarSessionRequest.SessionId), "Property is required for class CreateAirlineCfarSessionRequest.");
-
-            if (createAirlineCfarSessionRequest.ChannelOption.IsSet && createAirlineCfarSessionRequest.Channel == null)
-                throw new ArgumentNullException(nameof(createAirlineCfarSessionRequest.Channel), "Property is required for class CreateAirlineCfarSessionRequest.");
 
             writer.WriteString("point_of_sale", createAirlineCfarSessionRequest.PointOfSale);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateAirlineDgSessionRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateAirlineDgSessionRequest.cs
@@ -224,18 +224,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (language.IsSet && language.Value == null)
                 throw new ArgumentNullException(nameof(language), "Property is not nullable for class CreateAirlineDgSessionRequest.");
 
-            if (userInfo.IsSet && userInfo.Value == null)
-                throw new ArgumentNullException(nameof(userInfo), "Property is not nullable for class CreateAirlineDgSessionRequest.");
-
-            if (device.IsSet && device.Value == null)
-                throw new ArgumentNullException(nameof(device), "Property is not nullable for class CreateAirlineDgSessionRequest.");
-
-            if (sessionId.IsSet && sessionId.Value == null)
-                throw new ArgumentNullException(nameof(sessionId), "Property is not nullable for class CreateAirlineDgSessionRequest.");
-
-            if (channel.IsSet && channel.Value == null)
-                throw new ArgumentNullException(nameof(channel), "Property is not nullable for class CreateAirlineDgSessionRequest.");
-
             return new CreateAirlineDgSessionRequest(pointOfSale.Value!, language.Value!, userInfo, device, sessionId, channel);
         }
 
@@ -268,18 +256,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createAirlineDgSessionRequest.Language == null)
                 throw new ArgumentNullException(nameof(createAirlineDgSessionRequest.Language), "Property is required for class CreateAirlineDgSessionRequest.");
-
-            if (createAirlineDgSessionRequest.UserInfoOption.IsSet && createAirlineDgSessionRequest.UserInfo == null)
-                throw new ArgumentNullException(nameof(createAirlineDgSessionRequest.UserInfo), "Property is required for class CreateAirlineDgSessionRequest.");
-
-            if (createAirlineDgSessionRequest.DeviceOption.IsSet && createAirlineDgSessionRequest.Device == null)
-                throw new ArgumentNullException(nameof(createAirlineDgSessionRequest.Device), "Property is required for class CreateAirlineDgSessionRequest.");
-
-            if (createAirlineDgSessionRequest.SessionIdOption.IsSet && createAirlineDgSessionRequest.SessionId == null)
-                throw new ArgumentNullException(nameof(createAirlineDgSessionRequest.SessionId), "Property is required for class CreateAirlineDgSessionRequest.");
-
-            if (createAirlineDgSessionRequest.ChannelOption.IsSet && createAirlineDgSessionRequest.Channel == null)
-                throw new ArgumentNullException(nameof(createAirlineDgSessionRequest.Channel), "Property is required for class CreateAirlineDgSessionRequest.");
 
             writer.WriteString("point_of_sale", createAirlineDgSessionRequest.PointOfSale);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateAirlineSessionRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateAirlineSessionRequest.cs
@@ -246,18 +246,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (language.IsSet && language.Value == null)
                 throw new ArgumentNullException(nameof(language), "Property is not nullable for class CreateAirlineSessionRequest.");
 
-            if (userInfo.IsSet && userInfo.Value == null)
-                throw new ArgumentNullException(nameof(userInfo), "Property is not nullable for class CreateAirlineSessionRequest.");
-
-            if (sessionId.IsSet && sessionId.Value == null)
-                throw new ArgumentNullException(nameof(sessionId), "Property is not nullable for class CreateAirlineSessionRequest.");
-
-            if (device.IsSet && device.Value == null)
-                throw new ArgumentNullException(nameof(device), "Property is not nullable for class CreateAirlineSessionRequest.");
-
-            if (product.IsSet && product.Value == null)
-                throw new ArgumentNullException(nameof(product), "Property is not nullable for class CreateAirlineSessionRequest.");
-
             return new CreateAirlineSessionRequest(flowType.Value!.Value!, pointOfSale.Value!, language.Value!, userInfo, sessionId, device, product);
         }
 
@@ -290,15 +278,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createAirlineSessionRequest.Language == null)
                 throw new ArgumentNullException(nameof(createAirlineSessionRequest.Language), "Property is required for class CreateAirlineSessionRequest.");
-
-            if (createAirlineSessionRequest.UserInfoOption.IsSet && createAirlineSessionRequest.UserInfo == null)
-                throw new ArgumentNullException(nameof(createAirlineSessionRequest.UserInfo), "Property is required for class CreateAirlineSessionRequest.");
-
-            if (createAirlineSessionRequest.SessionIdOption.IsSet && createAirlineSessionRequest.SessionId == null)
-                throw new ArgumentNullException(nameof(createAirlineSessionRequest.SessionId), "Property is required for class CreateAirlineSessionRequest.");
-
-            if (createAirlineSessionRequest.DeviceOption.IsSet && createAirlineSessionRequest.Device == null)
-                throw new ArgumentNullException(nameof(createAirlineSessionRequest.Device), "Property is required for class CreateAirlineSessionRequest.");
 
             var flowTypeRawValue = FlowTypeValueConverter.ToJsonValue(createAirlineSessionRequest.FlowType);
             writer.WriteString("flow_type", flowTypeRawValue);

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateCfarContractExerciseRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateCfarContractExerciseRequest.cs
@@ -376,36 +376,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class CreateCfarContractExerciseRequest.");
 
-            if (contractId.IsSet && contractId.Value == null)
-                throw new ArgumentNullException(nameof(contractId), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (emailAddress.IsSet && emailAddress.Value == null)
-                throw new ArgumentNullException(nameof(emailAddress), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (airlineRefundPenalty.IsSet && airlineRefundPenalty.Value == null)
-                throw new ArgumentNullException(nameof(airlineRefundPenalty), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (airlineRefundMethod.IsSet && airlineRefundMethod.Value == null)
-                throw new ArgumentNullException(nameof(airlineRefundMethod), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (currency.IsSet && currency.Value == null)
-                throw new ArgumentNullException(nameof(currency), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (session.IsSet && session.Value == null)
-                throw new ArgumentNullException(nameof(session), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (callbackUrl.IsSet && callbackUrl.Value == null)
-                throw new ArgumentNullException(nameof(callbackUrl), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (redirectbackUrl.IsSet && redirectbackUrl.Value == null)
-                throw new ArgumentNullException(nameof(redirectbackUrl), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class CreateCfarContractExerciseRequest.");
-
             return new CreateCfarContractExerciseRequest(itinerary.Value!, pnrReference.Value!, extAttributes.Value!, contractId, emailAddress, airlineRefundPenalty, airlineRefundMethod, currency, session, callbackUrl, redirectbackUrl, firstName, lastName);
         }
 
@@ -441,33 +411,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createCfarContractExerciseRequest.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.ExtAttributes), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.ContractIdOption.IsSet && createCfarContractExerciseRequest.ContractId == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.ContractId), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.EmailAddressOption.IsSet && createCfarContractExerciseRequest.EmailAddress == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.EmailAddress), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.AirlineRefundPenaltyOption.IsSet && createCfarContractExerciseRequest.AirlineRefundPenalty == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.AirlineRefundPenalty), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.CurrencyOption.IsSet && createCfarContractExerciseRequest.Currency == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.Currency), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.SessionOption.IsSet && createCfarContractExerciseRequest.Session == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.Session), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.CallbackUrlOption.IsSet && createCfarContractExerciseRequest.CallbackUrl == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.CallbackUrl), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.RedirectbackUrlOption.IsSet && createCfarContractExerciseRequest.RedirectbackUrl == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.RedirectbackUrl), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.FirstNameOption.IsSet && createCfarContractExerciseRequest.FirstName == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.FirstName), "Property is required for class CreateCfarContractExerciseRequest.");
-
-            if (createCfarContractExerciseRequest.LastNameOption.IsSet && createCfarContractExerciseRequest.LastName == null)
-                throw new ArgumentNullException(nameof(createCfarContractExerciseRequest.LastName), "Property is required for class CreateCfarContractExerciseRequest.");
 
             writer.WritePropertyName("itinerary");
             JsonSerializer.Serialize(writer, createCfarContractExerciseRequest.Itinerary, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateCfarContractRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateCfarContractRequest.cs
@@ -181,9 +181,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class CreateCfarContractRequest.");
 
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class CreateCfarContractRequest.");
-
             return new CreateCfarContractRequest(offerIds.Value!, itinerary.Value!, extAttributes.Value!, pnrReference);
         }
 
@@ -219,9 +216,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createCfarContractRequest.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(createCfarContractRequest.ExtAttributes), "Property is required for class CreateCfarContractRequest.");
-
-            if (createCfarContractRequest.PnrReferenceOption.IsSet && createCfarContractRequest.PnrReference == null)
-                throw new ArgumentNullException(nameof(createCfarContractRequest.PnrReference), "Property is required for class CreateCfarContractRequest.");
 
             writer.WritePropertyName("offer_ids");
             JsonSerializer.Serialize(writer, createCfarContractRequest.OfferIds, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateCfarOfferRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateCfarOfferRequest.cs
@@ -229,15 +229,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class CreateCfarOfferRequest.");
 
-            if (bookingDateTime.IsSet && bookingDateTime.Value == null)
-                throw new ArgumentNullException(nameof(bookingDateTime), "Property is not nullable for class CreateCfarOfferRequest.");
-
-            if (session.IsSet && session.Value == null)
-                throw new ArgumentNullException(nameof(session), "Property is not nullable for class CreateCfarOfferRequest.");
-
-            if (entryPoint.IsSet && entryPoint.Value == null)
-                throw new ArgumentNullException(nameof(entryPoint), "Property is not nullable for class CreateCfarOfferRequest.");
-
             return new CreateCfarOfferRequest(itinerary.Value!, requestType.Value!.Value!, extAttributes.Value!, bookingDateTime, session, entryPoint);
         }
 
@@ -270,12 +261,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createCfarOfferRequest.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(createCfarOfferRequest.ExtAttributes), "Property is required for class CreateCfarOfferRequest.");
-
-            if (createCfarOfferRequest.SessionOption.IsSet && createCfarOfferRequest.Session == null)
-                throw new ArgumentNullException(nameof(createCfarOfferRequest.Session), "Property is required for class CreateCfarOfferRequest.");
-
-            if (createCfarOfferRequest.EntryPointOption.IsSet && createCfarOfferRequest.EntryPoint == null)
-                throw new ArgumentNullException(nameof(createCfarOfferRequest.EntryPoint), "Property is required for class CreateCfarOfferRequest.");
 
             writer.WritePropertyName("itinerary");
             JsonSerializer.Serialize(writer, createCfarOfferRequest.Itinerary, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateDgContractExerciseRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateDgContractExerciseRequest.cs
@@ -246,18 +246,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (pnrReference.IsSet && pnrReference.Value == null)
                 throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class CreateDgContractExerciseRequest.");
 
-            if (emailAddress.IsSet && emailAddress.Value == null)
-                throw new ArgumentNullException(nameof(emailAddress), "Property is not nullable for class CreateDgContractExerciseRequest.");
-
-            if (callbackUrl.IsSet && callbackUrl.Value == null)
-                throw new ArgumentNullException(nameof(callbackUrl), "Property is not nullable for class CreateDgContractExerciseRequest.");
-
-            if (redirectbackUrl.IsSet && redirectbackUrl.Value == null)
-                throw new ArgumentNullException(nameof(redirectbackUrl), "Property is not nullable for class CreateDgContractExerciseRequest.");
-
-            if (session.IsSet && session.Value == null)
-                throw new ArgumentNullException(nameof(session), "Property is not nullable for class CreateDgContractExerciseRequest.");
-
             return new CreateDgContractExerciseRequest(contractId.Value!, itinerary.Value!, pnrReference.Value!, emailAddress, callbackUrl, redirectbackUrl, session);
         }
 
@@ -293,18 +281,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createDgContractExerciseRequest.PnrReference == null)
                 throw new ArgumentNullException(nameof(createDgContractExerciseRequest.PnrReference), "Property is required for class CreateDgContractExerciseRequest.");
-
-            if (createDgContractExerciseRequest.EmailAddressOption.IsSet && createDgContractExerciseRequest.EmailAddress == null)
-                throw new ArgumentNullException(nameof(createDgContractExerciseRequest.EmailAddress), "Property is required for class CreateDgContractExerciseRequest.");
-
-            if (createDgContractExerciseRequest.CallbackUrlOption.IsSet && createDgContractExerciseRequest.CallbackUrl == null)
-                throw new ArgumentNullException(nameof(createDgContractExerciseRequest.CallbackUrl), "Property is required for class CreateDgContractExerciseRequest.");
-
-            if (createDgContractExerciseRequest.RedirectbackUrlOption.IsSet && createDgContractExerciseRequest.RedirectbackUrl == null)
-                throw new ArgumentNullException(nameof(createDgContractExerciseRequest.RedirectbackUrl), "Property is required for class CreateDgContractExerciseRequest.");
-
-            if (createDgContractExerciseRequest.SessionOption.IsSet && createDgContractExerciseRequest.Session == null)
-                throw new ArgumentNullException(nameof(createDgContractExerciseRequest.Session), "Property is required for class CreateDgContractExerciseRequest.");
 
             writer.WriteString("contract_id", createDgContractExerciseRequest.ContractId);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateDgContractExerciseResponse.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateDgContractExerciseResponse.cs
@@ -140,9 +140,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (id.IsSet && id.Value == null)
                 throw new ArgumentNullException(nameof(id), "Property is not nullable for class CreateDgContractExerciseResponse.");
 
-            if (redirectionUrl.IsSet && redirectionUrl.Value == null)
-                throw new ArgumentNullException(nameof(redirectionUrl), "Property is not nullable for class CreateDgContractExerciseResponse.");
-
             return new CreateDgContractExerciseResponse(id.Value!, redirectionUrl);
         }
 
@@ -172,9 +169,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (createDgContractExerciseResponse.Id == null)
                 throw new ArgumentNullException(nameof(createDgContractExerciseResponse.Id), "Property is required for class CreateDgContractExerciseResponse.");
-
-            if (createDgContractExerciseResponse.RedirectionUrlOption.IsSet && createDgContractExerciseResponse.RedirectionUrl == null)
-                throw new ArgumentNullException(nameof(createDgContractExerciseResponse.RedirectionUrl), "Property is required for class CreateDgContractExerciseResponse.");
 
             writer.WriteString("id", createDgContractExerciseResponse.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateDgContractRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateDgContractRequest.cs
@@ -181,9 +181,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class CreateDgContractRequest.");
 
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class CreateDgContractRequest.");
-
             return new CreateDgContractRequest(offerIds.Value!, itinerary.Value!, extAttributes.Value!, pnrReference);
         }
 
@@ -219,9 +216,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createDgContractRequest.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(createDgContractRequest.ExtAttributes), "Property is required for class CreateDgContractRequest.");
-
-            if (createDgContractRequest.PnrReferenceOption.IsSet && createDgContractRequest.PnrReference == null)
-                throw new ArgumentNullException(nameof(createDgContractRequest.PnrReference), "Property is required for class CreateDgContractRequest.");
 
             writer.WritePropertyName("offer_ids");
             JsonSerializer.Serialize(writer, createDgContractRequest.OfferIds, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateDgOfferItemResponse.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateDgOfferItemResponse.cs
@@ -590,24 +590,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (contents.IsSet && contents.Value == null)
                 throw new ArgumentNullException(nameof(contents), "Property is not nullable for class CreateDgOfferItemResponse.");
 
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class CreateDgOfferItemResponse.");
-
-            if (entryPoint.IsSet && entryPoint.Value == null)
-                throw new ArgumentNullException(nameof(entryPoint), "Property is not nullable for class CreateDgOfferItemResponse.");
-
-            if (termsConditionsUrl.IsSet && termsConditionsUrl.Value == null)
-                throw new ArgumentNullException(nameof(termsConditionsUrl), "Property is not nullable for class CreateDgOfferItemResponse.");
-
-            if (faqUrl.IsSet && faqUrl.Value == null)
-                throw new ArgumentNullException(nameof(faqUrl), "Property is not nullable for class CreateDgOfferItemResponse.");
-
-            if (merchandisingUrl.IsSet && merchandisingUrl.Value == null)
-                throw new ArgumentNullException(nameof(merchandisingUrl), "Property is not nullable for class CreateDgOfferItemResponse.");
-
-            if (merchandisingUrlWebComponent.IsSet && merchandisingUrlWebComponent.Value == null)
-                throw new ArgumentNullException(nameof(merchandisingUrlWebComponent), "Property is not nullable for class CreateDgOfferItemResponse.");
-
             return new CreateDgOfferItemResponse(id.Value!, premium.Value!, premiumPerPassenger.Value!, coverage.Value!, coveragePercentage.Value!, serviceCap.Value!, currency.Value!, taxesTotal.Value!, requestType.Value!.Value!, maxHoursBeforeDeparture.Value!.Value!, minMinutesDelay.Value!.Value!, createdDateTime.Value!.Value!, contractExpiryDateTime.Value!.Value!, itinerary.Value!, extAttributes.Value!, experiments.Value!, contents.Value!, taxes, entryPoint, termsConditionsUrl, faqUrl, merchandisingUrl, merchandisingUrlWebComponent);
         }
 
@@ -670,24 +652,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createDgOfferItemResponse.Contents == null)
                 throw new ArgumentNullException(nameof(createDgOfferItemResponse.Contents), "Property is required for class CreateDgOfferItemResponse.");
-
-            if (createDgOfferItemResponse.TaxesOption.IsSet && createDgOfferItemResponse.Taxes == null)
-                throw new ArgumentNullException(nameof(createDgOfferItemResponse.Taxes), "Property is required for class CreateDgOfferItemResponse.");
-
-            if (createDgOfferItemResponse.EntryPointOption.IsSet && createDgOfferItemResponse.EntryPoint == null)
-                throw new ArgumentNullException(nameof(createDgOfferItemResponse.EntryPoint), "Property is required for class CreateDgOfferItemResponse.");
-
-            if (createDgOfferItemResponse.TermsConditionsUrlOption.IsSet && createDgOfferItemResponse.TermsConditionsUrl == null)
-                throw new ArgumentNullException(nameof(createDgOfferItemResponse.TermsConditionsUrl), "Property is required for class CreateDgOfferItemResponse.");
-
-            if (createDgOfferItemResponse.FaqUrlOption.IsSet && createDgOfferItemResponse.FaqUrl == null)
-                throw new ArgumentNullException(nameof(createDgOfferItemResponse.FaqUrl), "Property is required for class CreateDgOfferItemResponse.");
-
-            if (createDgOfferItemResponse.MerchandisingUrlOption.IsSet && createDgOfferItemResponse.MerchandisingUrl == null)
-                throw new ArgumentNullException(nameof(createDgOfferItemResponse.MerchandisingUrl), "Property is required for class CreateDgOfferItemResponse.");
-
-            if (createDgOfferItemResponse.MerchandisingUrlWebComponentOption.IsSet && createDgOfferItemResponse.MerchandisingUrlWebComponent == null)
-                throw new ArgumentNullException(nameof(createDgOfferItemResponse.MerchandisingUrlWebComponent), "Property is required for class CreateDgOfferItemResponse.");
 
             writer.WriteString("id", createDgOfferItemResponse.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateDgOffersRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateDgOffersRequest.cs
@@ -229,15 +229,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class CreateDgOffersRequest.");
 
-            if (bookingDateTime.IsSet && bookingDateTime.Value == null)
-                throw new ArgumentNullException(nameof(bookingDateTime), "Property is not nullable for class CreateDgOffersRequest.");
-
-            if (session.IsSet && session.Value == null)
-                throw new ArgumentNullException(nameof(session), "Property is not nullable for class CreateDgOffersRequest.");
-
-            if (entryPoint.IsSet && entryPoint.Value == null)
-                throw new ArgumentNullException(nameof(entryPoint), "Property is not nullable for class CreateDgOffersRequest.");
-
             return new CreateDgOffersRequest(itinerary.Value!, requestType.Value!.Value!, extAttributes.Value!, bookingDateTime, session, entryPoint);
         }
 
@@ -270,12 +261,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createDgOffersRequest.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(createDgOffersRequest.ExtAttributes), "Property is required for class CreateDgOffersRequest.");
-
-            if (createDgOffersRequest.SessionOption.IsSet && createDgOffersRequest.Session == null)
-                throw new ArgumentNullException(nameof(createDgOffersRequest.Session), "Property is required for class CreateDgOffersRequest.");
-
-            if (createDgOffersRequest.EntryPointOption.IsSet && createDgOffersRequest.EntryPoint == null)
-                throw new ArgumentNullException(nameof(createDgOffersRequest.EntryPoint), "Property is required for class CreateDgOffersRequest.");
 
             writer.WritePropertyName("itinerary");
             JsonSerializer.Serialize(writer, createDgOffersRequest.Itinerary, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/CreateExternalCfarOfferRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/CreateExternalCfarOfferRequest.cs
@@ -404,12 +404,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (minMinutesDelay.IsSet && minMinutesDelay.Value == null)
                 throw new ArgumentNullException(nameof(minMinutesDelay), "Property is not nullable for class CreateExternalCfarOfferRequest.");
 
-            if (bookingDateTime.IsSet && bookingDateTime.Value == null)
-                throw new ArgumentNullException(nameof(bookingDateTime), "Property is not nullable for class CreateExternalCfarOfferRequest.");
-
-            if (session.IsSet && session.Value == null)
-                throw new ArgumentNullException(nameof(session), "Property is not nullable for class CreateExternalCfarOfferRequest.");
-
             return new CreateExternalCfarOfferRequest(externalId.Value!, countryCode.Value!, currency.Value!, toUsdExchangeRate.Value!, premiumTotalAmount.Value!, premiumPercentage.Value!, payoutTotalAmount.Value!, payoutPercentage.Value!, taxesTotal.Value!, contractExpiryDateTime.Value!.Value!, itinerary.Value!, minMinutesDelay.Value!.Value!, bookingDateTime, session);
         }
 
@@ -466,9 +460,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (createExternalCfarOfferRequest.Itinerary == null)
                 throw new ArgumentNullException(nameof(createExternalCfarOfferRequest.Itinerary), "Property is required for class CreateExternalCfarOfferRequest.");
-
-            if (createExternalCfarOfferRequest.SessionOption.IsSet && createExternalCfarOfferRequest.Session == null)
-                throw new ArgumentNullException(nameof(createExternalCfarOfferRequest.Session), "Property is required for class CreateExternalCfarOfferRequest.");
 
             writer.WriteString("external_id", createExternalCfarOfferRequest.ExternalId);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Desktop.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Desktop.cs
@@ -253,15 +253,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Desktop.");
 
-            if (platform.IsSet && platform.Value == null)
-                throw new ArgumentNullException(nameof(platform), "Property is not nullable for class Desktop.");
-
-            if (uiTheme.IsSet && uiTheme.Value == null)
-                throw new ArgumentNullException(nameof(uiTheme), "Property is not nullable for class Desktop.");
-
-            if (releaseBuild.IsSet && releaseBuild.Value == null)
-                throw new ArgumentNullException(nameof(releaseBuild), "Property is not nullable for class Desktop.");
-
             return new Desktop(id.Value!, type.Value!.Value!, platform, uiTheme, releaseBuild);
         }
 
@@ -291,15 +282,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (desktop.Id == null)
                 throw new ArgumentNullException(nameof(desktop.Id), "Property is required for class Desktop.");
-
-            if (desktop.PlatformOption.IsSet && desktop.Platform == null)
-                throw new ArgumentNullException(nameof(desktop.Platform), "Property is required for class Desktop.");
-
-            if (desktop.UiThemeOption.IsSet && desktop.UiTheme == null)
-                throw new ArgumentNullException(nameof(desktop.UiTheme), "Property is required for class Desktop.");
-
-            if (desktop.ReleaseBuildOption.IsSet && desktop.ReleaseBuild == null)
-                throw new ArgumentNullException(nameof(desktop.ReleaseBuild), "Property is required for class Desktop.");
 
             writer.WriteString("id", desktop.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgAncillary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgAncillary.cs
@@ -183,12 +183,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class DgAncillary.");
 
-            if (passengerReference.IsSet && passengerReference.Value == null)
-                throw new ArgumentNullException(nameof(passengerReference), "Property is not nullable for class DgAncillary.");
-
-            if (covered.IsSet && covered.Value == null)
-                throw new ArgumentNullException(nameof(covered), "Property is not nullable for class DgAncillary.");
-
             return new DgAncillary(totalPrice.Value!, type.Value!.Value!, passengerReference, covered);
         }
 
@@ -218,9 +212,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (dgAncillary.TotalPrice == null)
                 throw new ArgumentNullException(nameof(dgAncillary.TotalPrice), "Property is required for class DgAncillary.");
-
-            if (dgAncillary.PassengerReferenceOption.IsSet && dgAncillary.PassengerReference == null)
-                throw new ArgumentNullException(nameof(dgAncillary.PassengerReference), "Property is required for class DgAncillary.");
 
             writer.WriteString("total_price", dgAncillary.TotalPrice);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgContract.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgContract.cs
@@ -511,15 +511,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (extAttributes.IsSet && extAttributes.Value == null)
                 throw new ArgumentNullException(nameof(extAttributes), "Property is not nullable for class DgContract.");
 
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class DgContract.");
-
-            if (language.IsSet && language.Value == null)
-                throw new ArgumentNullException(nameof(language), "Property is not nullable for class DgContract.");
-
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class DgContract.");
-
             return new DgContract(id.Value!, reference.Value!, status.Value!.Value!, offers.Value!, itinerary.Value!, coveragePercentage.Value!, coverage.Value!, premium.Value!, serviceCap.Value!, currency.Value!, taxesTotal.Value!, maxHoursBeforeDeparture.Value!.Value!, minMinutesDelay.Value!.Value!, createdDateTime.Value!.Value!, expiryDateTime.Value!.Value!, extAttributes.Value!, taxes, language, pnrReference);
         }
 
@@ -579,15 +570,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgContract.ExtAttributes == null)
                 throw new ArgumentNullException(nameof(dgContract.ExtAttributes), "Property is required for class DgContract.");
-
-            if (dgContract.TaxesOption.IsSet && dgContract.Taxes == null)
-                throw new ArgumentNullException(nameof(dgContract.Taxes), "Property is required for class DgContract.");
-
-            if (dgContract.LanguageOption.IsSet && dgContract.Language == null)
-                throw new ArgumentNullException(nameof(dgContract.Language), "Property is required for class DgContract.");
-
-            if (dgContract.PnrReferenceOption.IsSet && dgContract.PnrReference == null)
-                throw new ArgumentNullException(nameof(dgContract.PnrReference), "Property is required for class DgContract.");
 
             writer.WriteString("id", dgContract.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgExerciseItinerary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgExerciseItinerary.cs
@@ -161,9 +161,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (slices.IsSet && slices.Value == null)
                 throw new ArgumentNullException(nameof(slices), "Property is not nullable for class DgExerciseItinerary.");
 
-            if (passengers.IsSet && passengers.Value == null)
-                throw new ArgumentNullException(nameof(passengers), "Property is not nullable for class DgExerciseItinerary.");
-
             return new DgExerciseItinerary(passengerCount.Value!, slices.Value!, passengers);
         }
 
@@ -196,9 +193,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgExerciseItinerary.Slices == null)
                 throw new ArgumentNullException(nameof(dgExerciseItinerary.Slices), "Property is required for class DgExerciseItinerary.");
-
-            if (dgExerciseItinerary.PassengersOption.IsSet && dgExerciseItinerary.Passengers == null)
-                throw new ArgumentNullException(nameof(dgExerciseItinerary.Passengers), "Property is required for class DgExerciseItinerary.");
 
             writer.WritePropertyName("passenger_count");
             JsonSerializer.Serialize(writer, dgExerciseItinerary.PassengerCount, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/DgExerciseItinerarySlice.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgExerciseItinerarySlice.cs
@@ -183,15 +183,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (segments.IsSet && segments.Value == null)
                 throw new ArgumentNullException(nameof(segments), "Property is not nullable for class DgExerciseItinerarySlice.");
 
-            if (irop.IsSet && irop.Value == null)
-                throw new ArgumentNullException(nameof(irop), "Property is not nullable for class DgExerciseItinerarySlice.");
-
-            if (invol.IsSet && invol.Value == null)
-                throw new ArgumentNullException(nameof(invol), "Property is not nullable for class DgExerciseItinerarySlice.");
-
-            if (previousSlice.IsSet && previousSlice.Value == null)
-                throw new ArgumentNullException(nameof(previousSlice), "Property is not nullable for class DgExerciseItinerarySlice.");
-
             return new DgExerciseItinerarySlice(segments.Value!, irop, invol, previousSlice);
         }
 
@@ -221,9 +212,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (dgExerciseItinerarySlice.Segments == null)
                 throw new ArgumentNullException(nameof(dgExerciseItinerarySlice.Segments), "Property is required for class DgExerciseItinerarySlice.");
-
-            if (dgExerciseItinerarySlice.PreviousSliceOption.IsSet && dgExerciseItinerarySlice.PreviousSlice == null)
-                throw new ArgumentNullException(nameof(dgExerciseItinerarySlice.PreviousSlice), "Property is required for class DgExerciseItinerarySlice.");
 
             writer.WritePropertyName("segments");
             JsonSerializer.Serialize(writer, dgExerciseItinerarySlice.Segments, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/DgExerciseItinerarySliceSegment.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgExerciseItinerarySliceSegment.cs
@@ -417,21 +417,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (flightStatus.IsSet && flightStatus.Value == null)
                 throw new ArgumentNullException(nameof(flightStatus), "Property is not nullable for class DgExerciseItinerarySliceSegment.");
 
-            if (checkedIn.IsSet && checkedIn.Value == null)
-                throw new ArgumentNullException(nameof(checkedIn), "Property is not nullable for class DgExerciseItinerarySliceSegment.");
-
-            if (checkedInBags.IsSet && checkedInBags.Value == null)
-                throw new ArgumentNullException(nameof(checkedInBags), "Property is not nullable for class DgExerciseItinerarySliceSegment.");
-
-            if (checkedBagAllowance.IsSet && checkedBagAllowance.Value == null)
-                throw new ArgumentNullException(nameof(checkedBagAllowance), "Property is not nullable for class DgExerciseItinerarySliceSegment.");
-
-            if (boarded.IsSet && boarded.Value == null)
-                throw new ArgumentNullException(nameof(boarded), "Property is not nullable for class DgExerciseItinerarySliceSegment.");
-
-            if (flown.IsSet && flown.Value == null)
-                throw new ArgumentNullException(nameof(flown), "Property is not nullable for class DgExerciseItinerarySliceSegment.");
-
             return new DgExerciseItinerarySliceSegment(originAirport.Value!, destinationAirport.Value!, departureDateTime.Value!, arrivalDateTime.Value!, estimatedDepartureDateTime.Value!, estimatedArrivalDateTime.Value!, flightNumber.Value!, validatingCarrierCode.Value!, cabin.Value!.Value!, flightStatus.Value!.Value!, checkedIn, checkedInBags, checkedBagAllowance, boarded, flown);
         }
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgItinerary.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgItinerary.cs
@@ -226,15 +226,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (slices.IsSet && slices.Value == null)
                 throw new ArgumentNullException(nameof(slices), "Property is not nullable for class DgItinerary.");
 
-            if (ancillaries.IsSet && ancillaries.Value == null)
-                throw new ArgumentNullException(nameof(ancillaries), "Property is not nullable for class DgItinerary.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class DgItinerary.");
-
-            if (passengers.IsSet && passengers.Value == null)
-                throw new ArgumentNullException(nameof(passengers), "Property is not nullable for class DgItinerary.");
-
             return new DgItinerary(passengerPricing.Value!, currency.Value!, slices.Value!, ancillaries, totalPrice, passengers);
         }
 
@@ -270,15 +261,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgItinerary.Slices == null)
                 throw new ArgumentNullException(nameof(dgItinerary.Slices), "Property is required for class DgItinerary.");
-
-            if (dgItinerary.AncillariesOption.IsSet && dgItinerary.Ancillaries == null)
-                throw new ArgumentNullException(nameof(dgItinerary.Ancillaries), "Property is required for class DgItinerary.");
-
-            if (dgItinerary.TotalPriceOption.IsSet && dgItinerary.TotalPrice == null)
-                throw new ArgumentNullException(nameof(dgItinerary.TotalPrice), "Property is required for class DgItinerary.");
-
-            if (dgItinerary.PassengersOption.IsSet && dgItinerary.Passengers == null)
-                throw new ArgumentNullException(nameof(dgItinerary.Passengers), "Property is required for class DgItinerary.");
 
             writer.WritePropertyName("passenger_pricing");
             JsonSerializer.Serialize(writer, dgItinerary.PassengerPricing, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/DgItinerarySlice.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgItinerarySlice.cs
@@ -162,12 +162,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (segments.IsSet && segments.Value == null)
                 throw new ArgumentNullException(nameof(segments), "Property is not nullable for class DgItinerarySlice.");
 
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class DgItinerarySlice.");
-
-            if (passengerPricing.IsSet && passengerPricing.Value == null)
-                throw new ArgumentNullException(nameof(passengerPricing), "Property is not nullable for class DgItinerarySlice.");
-
             return new DgItinerarySlice(segments.Value!, fareBrand, passengerPricing);
         }
 
@@ -197,12 +191,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (dgItinerarySlice.Segments == null)
                 throw new ArgumentNullException(nameof(dgItinerarySlice.Segments), "Property is required for class DgItinerarySlice.");
-
-            if (dgItinerarySlice.FareBrandOption.IsSet && dgItinerarySlice.FareBrand == null)
-                throw new ArgumentNullException(nameof(dgItinerarySlice.FareBrand), "Property is required for class DgItinerarySlice.");
-
-            if (dgItinerarySlice.PassengerPricingOption.IsSet && dgItinerarySlice.PassengerPricing == null)
-                throw new ArgumentNullException(nameof(dgItinerarySlice.PassengerPricing), "Property is required for class DgItinerarySlice.");
 
             writer.WritePropertyName("segments");
             JsonSerializer.Serialize(writer, dgItinerarySlice.Segments, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/DgItinerarySliceSegment.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgItinerarySliceSegment.cs
@@ -287,12 +287,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (cabin.IsSet && cabin.Value == null)
                 throw new ArgumentNullException(nameof(cabin), "Property is not nullable for class DgItinerarySliceSegment.");
 
-            if (segmentId.IsSet && segmentId.Value == null)
-                throw new ArgumentNullException(nameof(segmentId), "Property is not nullable for class DgItinerarySliceSegment.");
-
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class DgItinerarySliceSegment.");
-
             return new DgItinerarySliceSegment(originAirport.Value!, destinationAirport.Value!, departureDateTime.Value!, arrivalDateTime.Value!, flightNumber.Value!, validatingCarrierCode.Value!, cabin.Value!.Value!, segmentId, fareBrand);
         }
 
@@ -337,12 +331,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgItinerarySliceSegment.ValidatingCarrierCode == null)
                 throw new ArgumentNullException(nameof(dgItinerarySliceSegment.ValidatingCarrierCode), "Property is required for class DgItinerarySliceSegment.");
-
-            if (dgItinerarySliceSegment.SegmentIdOption.IsSet && dgItinerarySliceSegment.SegmentId == null)
-                throw new ArgumentNullException(nameof(dgItinerarySliceSegment.SegmentId), "Property is required for class DgItinerarySliceSegment.");
-
-            if (dgItinerarySliceSegment.FareBrandOption.IsSet && dgItinerarySliceSegment.FareBrand == null)
-                throw new ArgumentNullException(nameof(dgItinerarySliceSegment.FareBrand), "Property is required for class DgItinerarySliceSegment.");
 
             writer.WriteString("origin_airport", dgItinerarySliceSegment.OriginAirport);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgOffer.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgOffer.cs
@@ -568,24 +568,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (contents.IsSet && contents.Value == null)
                 throw new ArgumentNullException(nameof(contents), "Property is not nullable for class DgOffer.");
 
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class DgOffer.");
-
-            if (entryPoint.IsSet && entryPoint.Value == null)
-                throw new ArgumentNullException(nameof(entryPoint), "Property is not nullable for class DgOffer.");
-
-            if (termsConditionsUrl.IsSet && termsConditionsUrl.Value == null)
-                throw new ArgumentNullException(nameof(termsConditionsUrl), "Property is not nullable for class DgOffer.");
-
-            if (faqUrl.IsSet && faqUrl.Value == null)
-                throw new ArgumentNullException(nameof(faqUrl), "Property is not nullable for class DgOffer.");
-
-            if (merchandisingUrl.IsSet && merchandisingUrl.Value == null)
-                throw new ArgumentNullException(nameof(merchandisingUrl), "Property is not nullable for class DgOffer.");
-
-            if (merchandisingUrlWebComponent.IsSet && merchandisingUrlWebComponent.Value == null)
-                throw new ArgumentNullException(nameof(merchandisingUrlWebComponent), "Property is not nullable for class DgOffer.");
-
             return new DgOffer(id.Value!, premium.Value!, coverage.Value!, coveragePercentage.Value!, serviceCap.Value!, currency.Value!, taxesTotal.Value!, requestType.Value!.Value!, maxHoursBeforeDeparture.Value!.Value!, minMinutesDelay.Value!.Value!, contractExpiryDateTime.Value!.Value!, createdDateTime.Value!.Value!, itinerary.Value!, extAttributes.Value!, experiments.Value!, contents.Value!, taxes, entryPoint, termsConditionsUrl, faqUrl, merchandisingUrl, merchandisingUrlWebComponent);
         }
 
@@ -645,24 +627,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgOffer.Contents == null)
                 throw new ArgumentNullException(nameof(dgOffer.Contents), "Property is required for class DgOffer.");
-
-            if (dgOffer.TaxesOption.IsSet && dgOffer.Taxes == null)
-                throw new ArgumentNullException(nameof(dgOffer.Taxes), "Property is required for class DgOffer.");
-
-            if (dgOffer.EntryPointOption.IsSet && dgOffer.EntryPoint == null)
-                throw new ArgumentNullException(nameof(dgOffer.EntryPoint), "Property is required for class DgOffer.");
-
-            if (dgOffer.TermsConditionsUrlOption.IsSet && dgOffer.TermsConditionsUrl == null)
-                throw new ArgumentNullException(nameof(dgOffer.TermsConditionsUrl), "Property is required for class DgOffer.");
-
-            if (dgOffer.FaqUrlOption.IsSet && dgOffer.FaqUrl == null)
-                throw new ArgumentNullException(nameof(dgOffer.FaqUrl), "Property is required for class DgOffer.");
-
-            if (dgOffer.MerchandisingUrlOption.IsSet && dgOffer.MerchandisingUrl == null)
-                throw new ArgumentNullException(nameof(dgOffer.MerchandisingUrl), "Property is required for class DgOffer.");
-
-            if (dgOffer.MerchandisingUrlWebComponentOption.IsSet && dgOffer.MerchandisingUrlWebComponent == null)
-                throw new ArgumentNullException(nameof(dgOffer.MerchandisingUrlWebComponent), "Property is required for class DgOffer.");
 
             writer.WriteString("id", dgOffer.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgPassenger.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgPassenger.cs
@@ -337,33 +337,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (passengerType.IsSet && passengerType.Value == null)
                 throw new ArgumentNullException(nameof(passengerType), "Property is not nullable for class DgPassenger.");
 
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class DgPassenger.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class DgPassenger.");
-
-            if (dateOfBirth.IsSet && dateOfBirth.Value == null)
-                throw new ArgumentNullException(nameof(dateOfBirth), "Property is not nullable for class DgPassenger.");
-
-            if (gender.IsSet && gender.Value == null)
-                throw new ArgumentNullException(nameof(gender), "Property is not nullable for class DgPassenger.");
-
-            if (passportNumber.IsSet && passportNumber.Value == null)
-                throw new ArgumentNullException(nameof(passportNumber), "Property is not nullable for class DgPassenger.");
-
-            if (passportCountryIssuance.IsSet && passportCountryIssuance.Value == null)
-                throw new ArgumentNullException(nameof(passportCountryIssuance), "Property is not nullable for class DgPassenger.");
-
-            if (passportIssuanceDate.IsSet && passportIssuanceDate.Value == null)
-                throw new ArgumentNullException(nameof(passportIssuanceDate), "Property is not nullable for class DgPassenger.");
-
-            if (passportExpirationDate.IsSet && passportExpirationDate.Value == null)
-                throw new ArgumentNullException(nameof(passportExpirationDate), "Property is not nullable for class DgPassenger.");
-
-            if (nationality.IsSet && nationality.Value == null)
-                throw new ArgumentNullException(nameof(nationality), "Property is not nullable for class DgPassenger.");
-
             return new DgPassenger(passengerReference.Value!, passengerType.Value!.Value!, firstName, lastName, dateOfBirth, gender, passportNumber, passportCountryIssuance, passportIssuanceDate, passportExpirationDate, nationality);
         }
 
@@ -393,30 +366,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (dgPassenger.PassengerReference == null)
                 throw new ArgumentNullException(nameof(dgPassenger.PassengerReference), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.FirstNameOption.IsSet && dgPassenger.FirstName == null)
-                throw new ArgumentNullException(nameof(dgPassenger.FirstName), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.LastNameOption.IsSet && dgPassenger.LastName == null)
-                throw new ArgumentNullException(nameof(dgPassenger.LastName), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.DateOfBirthOption.IsSet && dgPassenger.DateOfBirth == null)
-                throw new ArgumentNullException(nameof(dgPassenger.DateOfBirth), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.PassportNumberOption.IsSet && dgPassenger.PassportNumber == null)
-                throw new ArgumentNullException(nameof(dgPassenger.PassportNumber), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.PassportCountryIssuanceOption.IsSet && dgPassenger.PassportCountryIssuance == null)
-                throw new ArgumentNullException(nameof(dgPassenger.PassportCountryIssuance), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.PassportIssuanceDateOption.IsSet && dgPassenger.PassportIssuanceDate == null)
-                throw new ArgumentNullException(nameof(dgPassenger.PassportIssuanceDate), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.PassportExpirationDateOption.IsSet && dgPassenger.PassportExpirationDate == null)
-                throw new ArgumentNullException(nameof(dgPassenger.PassportExpirationDate), "Property is required for class DgPassenger.");
-
-            if (dgPassenger.NationalityOption.IsSet && dgPassenger.Nationality == null)
-                throw new ArgumentNullException(nameof(dgPassenger.Nationality), "Property is required for class DgPassenger.");
 
             writer.WriteString("passenger_reference", dgPassenger.PassengerReference);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/DgPassengerPricing.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgPassengerPricing.cs
@@ -160,9 +160,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (individualPrice.IsSet && individualPrice.Value == null)
                 throw new ArgumentNullException(nameof(individualPrice), "Property is not nullable for class DgPassengerPricing.");
 
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class DgPassengerPricing.");
-
             return new DgPassengerPricing(passengerCount.Value!, individualPrice.Value!, taxes);
         }
 
@@ -195,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgPassengerPricing.IndividualPrice == null)
                 throw new ArgumentNullException(nameof(dgPassengerPricing.IndividualPrice), "Property is required for class DgPassengerPricing.");
-
-            if (dgPassengerPricing.TaxesOption.IsSet && dgPassengerPricing.Taxes == null)
-                throw new ArgumentNullException(nameof(dgPassengerPricing.Taxes), "Property is required for class DgPassengerPricing.");
 
             writer.WritePropertyName("passenger_count");
             JsonSerializer.Serialize(writer, dgPassengerPricing.PassengerCount, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/DgTax.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/DgTax.cs
@@ -182,9 +182,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (amount.IsSet && amount.Value == null)
                 throw new ArgumentNullException(nameof(amount), "Property is not nullable for class DgTax.");
 
-            if (registrationNumber.IsSet && registrationNumber.Value == null)
-                throw new ArgumentNullException(nameof(registrationNumber), "Property is not nullable for class DgTax.");
-
             return new DgTax(name.Value!, rate.Value!, amount.Value!, registrationNumber);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (dgTax.Amount == null)
                 throw new ArgumentNullException(nameof(dgTax.Amount), "Property is required for class DgTax.");
-
-            if (dgTax.RegistrationNumberOption.IsSet && dgTax.RegistrationNumber == null)
-                throw new ArgumentNullException(nameof(dgTax.RegistrationNumber), "Property is required for class DgTax.");
 
             writer.WriteString("name", dgTax.Name);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Edge.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Edge.cs
@@ -190,9 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Edge.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Edge.");
-
             return new Edge(type.Value!.Value!, varVersion);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Edge edge, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (edge.VarVersionOption.IsSet && edge.VarVersion == null)
-                throw new ArgumentNullException(nameof(edge.VarVersion), "Property is required for class Edge.");
-
             var typeRawValue = Edge.TypeEnumToJsonValue(edge.Type);
             writer.WriteString("type", typeRawValue);
             if (edge.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/Error.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Error.cs
@@ -157,12 +157,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (message.IsSet && message.Value == null)
                 throw new ArgumentNullException(nameof(message), "Property is not nullable for class Error.");
 
-            if (code.IsSet && code.Value == null)
-                throw new ArgumentNullException(nameof(code), "Property is not nullable for class Error.");
-
-            if (messages.IsSet && messages.Value == null)
-                throw new ArgumentNullException(nameof(messages), "Property is not nullable for class Error.");
-
             return new Error(message.Value!, code, messages);
         }
 
@@ -192,12 +186,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (error.Message == null)
                 throw new ArgumentNullException(nameof(error.Message), "Property is required for class Error.");
-
-            if (error.CodeOption.IsSet && error.Code == null)
-                throw new ArgumentNullException(nameof(error.Code), "Property is required for class Error.");
-
-            if (error.MessagesOption.IsSet && error.Messages == null)
-                throw new ArgumentNullException(nameof(error.Messages), "Property is required for class Error.");
 
             writer.WriteString("message", error.Message);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Fare.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Fare.cs
@@ -185,18 +185,6 @@ namespace Com.Hopper.Hts.Airlines.Model
                 }
             }
 
-            if (price.IsSet && price.Value == null)
-                throw new ArgumentNullException(nameof(price), "Property is not nullable for class Fare.");
-
-            if (fareBrand.IsSet && fareBrand.Value == null)
-                throw new ArgumentNullException(nameof(fareBrand), "Property is not nullable for class Fare.");
-
-            if (fareBasis.IsSet && fareBasis.Value == null)
-                throw new ArgumentNullException(nameof(fareBasis), "Property is not nullable for class Fare.");
-
-            if (fareRules.IsSet && fareRules.Value == null)
-                throw new ArgumentNullException(nameof(fareRules), "Property is not nullable for class Fare.");
-
             return new Fare(price, fareBrand, fareBasis, fareRules);
         }
 
@@ -224,18 +212,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Fare fare, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (fare.PriceOption.IsSet && fare.Price == null)
-                throw new ArgumentNullException(nameof(fare.Price), "Property is required for class Fare.");
-
-            if (fare.FareBrandOption.IsSet && fare.FareBrand == null)
-                throw new ArgumentNullException(nameof(fare.FareBrand), "Property is required for class Fare.");
-
-            if (fare.FareBasisOption.IsSet && fare.FareBasis == null)
-                throw new ArgumentNullException(nameof(fare.FareBasis), "Property is required for class Fare.");
-
-            if (fare.FareRulesOption.IsSet && fare.FareRules == null)
-                throw new ArgumentNullException(nameof(fare.FareRules), "Property is required for class Fare.");
-
             if (fare.PriceOption.IsSet)
                 writer.WriteString("price", fare.Price);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/FareRule.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/FareRule.cs
@@ -246,18 +246,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (allowed.IsSet && allowed.Value == null)
                 throw new ArgumentNullException(nameof(allowed), "Property is not nullable for class FareRule.");
 
-            if (fee.IsSet && fee.Value == null)
-                throw new ArgumentNullException(nameof(fee), "Property is not nullable for class FareRule.");
-
-            if (percentage.IsSet && percentage.Value == null)
-                throw new ArgumentNullException(nameof(percentage), "Property is not nullable for class FareRule.");
-
-            if (refundMethod.IsSet && refundMethod.Value == null)
-                throw new ArgumentNullException(nameof(refundMethod), "Property is not nullable for class FareRule.");
-
-            if (currency.IsSet && currency.Value == null)
-                throw new ArgumentNullException(nameof(currency), "Property is not nullable for class FareRule.");
-
             return new FareRule(modificationType.Value!.Value!, modificationTime.Value!.Value!, allowed.Value!.Value!, fee, percentage, refundMethod, currency);
         }
 
@@ -285,15 +273,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, FareRule fareRule, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (fareRule.FeeOption.IsSet && fareRule.Fee == null)
-                throw new ArgumentNullException(nameof(fareRule.Fee), "Property is required for class FareRule.");
-
-            if (fareRule.PercentageOption.IsSet && fareRule.Percentage == null)
-                throw new ArgumentNullException(nameof(fareRule.Percentage), "Property is required for class FareRule.");
-
-            if (fareRule.CurrencyOption.IsSet && fareRule.Currency == null)
-                throw new ArgumentNullException(nameof(fareRule.Currency), "Property is required for class FareRule.");
-
             var modificationTypeRawValue = ModificationTypeValueConverter.ToJsonValue(fareRule.ModificationType);
             writer.WriteString("modification_type", modificationTypeRawValue);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Firefox.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Firefox.cs
@@ -190,9 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Firefox.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Firefox.");
-
             return new Firefox(type.Value!.Value!, varVersion);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Firefox firefox, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (firefox.VarVersionOption.IsSet && firefox.VarVersion == null)
-                throw new ArgumentNullException(nameof(firefox.VarVersion), "Property is required for class Firefox.");
-
             var typeRawValue = Firefox.TypeEnumToJsonValue(firefox.Type);
             writer.WriteString("type", typeRawValue);
             if (firefox.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/IOs.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/IOs.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class IOs.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class IOs.");
-
             return new IOs(type.Value!.Value!, varVersion);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, IOs iOs, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (iOs.VarVersionOption.IsSet && iOs.VarVersion == null)
-                throw new ArgumentNullException(nameof(iOs.VarVersion), "Property is required for class IOs.");
-
             var typeRawValue = IOs.TypeEnumToJsonValue(iOs.Type);
             writer.WriteString("type", typeRawValue);
             if (iOs.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/InternetExplorer.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/InternetExplorer.cs
@@ -190,9 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class InternetExplorer.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class InternetExplorer.");
-
             return new InternetExplorer(type.Value!.Value!, varVersion);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, InternetExplorer internetExplorer, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (internetExplorer.VarVersionOption.IsSet && internetExplorer.VarVersion == null)
-                throw new ArgumentNullException(nameof(internetExplorer.VarVersion), "Property is required for class InternetExplorer.");
-
             var typeRawValue = InternetExplorer.TypeEnumToJsonValue(internetExplorer.Type);
             writer.WriteString("type", typeRawValue);
             if (internetExplorer.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/Linux.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Linux.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Linux.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Linux.");
-
             return new Linux(type.Value!.Value!, varVersion);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Linux linux, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (linux.VarVersionOption.IsSet && linux.VarVersion == null)
-                throw new ArgumentNullException(nameof(linux.VarVersion), "Property is required for class Linux.");
-
             var typeRawValue = Linux.TypeEnumToJsonValue(linux.Type);
             writer.WriteString("type", typeRawValue);
             if (linux.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/MacOs.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/MacOs.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class MacOs.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class MacOs.");
-
             return new MacOs(type.Value!.Value!, varVersion);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MacOs macOs, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (macOs.VarVersionOption.IsSet && macOs.VarVersion == null)
-                throw new ArgumentNullException(nameof(macOs.VarVersion), "Property is required for class MacOs.");
-
             var typeRawValue = MacOs.TypeEnumToJsonValue(macOs.Type);
             writer.WriteString("type", typeRawValue);
             if (macOs.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/MarkCfarContractExerciseCompleteRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/MarkCfarContractExerciseCompleteRequest.cs
@@ -141,12 +141,6 @@ namespace Com.Hopper.Hts.Airlines.Model
                 }
             }
 
-            if (refundAmount.IsSet && refundAmount.Value == null)
-                throw new ArgumentNullException(nameof(refundAmount), "Property is not nullable for class MarkCfarContractExerciseCompleteRequest.");
-
-            if (refundMethod.IsSet && refundMethod.Value == null)
-                throw new ArgumentNullException(nameof(refundMethod), "Property is not nullable for class MarkCfarContractExerciseCompleteRequest.");
-
             return new MarkCfarContractExerciseCompleteRequest(refundAmount, refundMethod);
         }
 
@@ -174,9 +168,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, MarkCfarContractExerciseCompleteRequest markCfarContractExerciseCompleteRequest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (markCfarContractExerciseCompleteRequest.RefundAmountOption.IsSet && markCfarContractExerciseCompleteRequest.RefundAmount == null)
-                throw new ArgumentNullException(nameof(markCfarContractExerciseCompleteRequest.RefundAmount), "Property is required for class MarkCfarContractExerciseCompleteRequest.");
-
             if (markCfarContractExerciseCompleteRequest.RefundAmountOption.IsSet)
                 writer.WriteString("refund_amount", markCfarContractExerciseCompleteRequest.RefundAmount);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Mobile.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Mobile.cs
@@ -253,15 +253,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Mobile.");
 
-            if (platform.IsSet && platform.Value == null)
-                throw new ArgumentNullException(nameof(platform), "Property is not nullable for class Mobile.");
-
-            if (uiTheme.IsSet && uiTheme.Value == null)
-                throw new ArgumentNullException(nameof(uiTheme), "Property is not nullable for class Mobile.");
-
-            if (releaseBuild.IsSet && releaseBuild.Value == null)
-                throw new ArgumentNullException(nameof(releaseBuild), "Property is not nullable for class Mobile.");
-
             return new Mobile(id.Value!, type.Value!.Value!, platform, uiTheme, releaseBuild);
         }
 
@@ -291,15 +282,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (mobile.Id == null)
                 throw new ArgumentNullException(nameof(mobile.Id), "Property is required for class Mobile.");
-
-            if (mobile.PlatformOption.IsSet && mobile.Platform == null)
-                throw new ArgumentNullException(nameof(mobile.Platform), "Property is required for class Mobile.");
-
-            if (mobile.UiThemeOption.IsSet && mobile.UiTheme == null)
-                throw new ArgumentNullException(nameof(mobile.UiTheme), "Property is required for class Mobile.");
-
-            if (mobile.ReleaseBuildOption.IsSet && mobile.ReleaseBuild == null)
-                throw new ArgumentNullException(nameof(mobile.ReleaseBuild), "Property is required for class Mobile.");
 
             writer.WriteString("id", mobile.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Opera.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Opera.cs
@@ -190,9 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Opera.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Opera.");
-
             return new Opera(type.Value!.Value!, varVersion);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Opera opera, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (opera.VarVersionOption.IsSet && opera.VarVersion == null)
-                throw new ArgumentNullException(nameof(opera.VarVersion), "Property is required for class Opera.");
-
             var typeRawValue = Opera.TypeEnumToJsonValue(opera.Type);
             writer.WriteString("type", typeRawValue);
             if (opera.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/OtherBrowser.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/OtherBrowser.cs
@@ -209,9 +209,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class OtherBrowser.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class OtherBrowser.");
-
             return new OtherBrowser(name.Value!, type.Value!.Value!, varVersion);
         }
 
@@ -241,9 +238,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (otherBrowser.Name == null)
                 throw new ArgumentNullException(nameof(otherBrowser.Name), "Property is required for class OtherBrowser.");
-
-            if (otherBrowser.VarVersionOption.IsSet && otherBrowser.VarVersion == null)
-                throw new ArgumentNullException(nameof(otherBrowser.VarVersion), "Property is required for class OtherBrowser.");
 
             writer.WriteString("name", otherBrowser.Name);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/OtherOs.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/OtherOs.cs
@@ -211,9 +211,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class OtherOs.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class OtherOs.");
-
             return new OtherOs(name.Value!, type.Value!.Value!, varVersion);
         }
 
@@ -243,9 +240,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (otherOs.Name == null)
                 throw new ArgumentNullException(nameof(otherOs.Name), "Property is required for class OtherOs.");
-
-            if (otherOs.VarVersionOption.IsSet && otherOs.VarVersion == null)
-                throw new ArgumentNullException(nameof(otherOs.VarVersion), "Property is required for class OtherOs.");
 
             writer.WriteString("name", otherOs.Name);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/PassengerPricing.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/PassengerPricing.cs
@@ -160,9 +160,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (individualPrice.IsSet && individualPrice.Value == null)
                 throw new ArgumentNullException(nameof(individualPrice), "Property is not nullable for class PassengerPricing.");
 
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class PassengerPricing.");
-
             return new PassengerPricing(passengerCount.Value!, individualPrice.Value!, taxes);
         }
 
@@ -195,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (passengerPricing.IndividualPrice == null)
                 throw new ArgumentNullException(nameof(passengerPricing.IndividualPrice), "Property is required for class PassengerPricing.");
-
-            if (passengerPricing.TaxesOption.IsSet && passengerPricing.Taxes == null)
-                throw new ArgumentNullException(nameof(passengerPricing.Taxes), "Property is required for class PassengerPricing.");
 
             writer.WritePropertyName("passenger_count");
             JsonSerializer.Serialize(writer, passengerPricing.PassengerCount, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/PaymentCard.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/PaymentCard.cs
@@ -297,18 +297,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class PaymentCard.");
 
-            if (token.IsSet && token.Value == null)
-                throw new ArgumentNullException(nameof(token), "Property is not nullable for class PaymentCard.");
-
-            if (lastFourDigits.IsSet && lastFourDigits.Value == null)
-                throw new ArgumentNullException(nameof(lastFourDigits), "Property is not nullable for class PaymentCard.");
-
-            if (expirationMonth.IsSet && expirationMonth.Value == null)
-                throw new ArgumentNullException(nameof(expirationMonth), "Property is not nullable for class PaymentCard.");
-
-            if (expirationYear.IsSet && expirationYear.Value == null)
-                throw new ArgumentNullException(nameof(expirationYear), "Property is not nullable for class PaymentCard.");
-
             return new PaymentCard(amount.Value!, currency.Value!, type.Value!.Value!, token, lastFourDigits, expirationMonth, expirationYear);
         }
 
@@ -341,18 +329,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (paymentCard.Currency == null)
                 throw new ArgumentNullException(nameof(paymentCard.Currency), "Property is required for class PaymentCard.");
-
-            if (paymentCard.TokenOption.IsSet && paymentCard.Token == null)
-                throw new ArgumentNullException(nameof(paymentCard.Token), "Property is required for class PaymentCard.");
-
-            if (paymentCard.LastFourDigitsOption.IsSet && paymentCard.LastFourDigits == null)
-                throw new ArgumentNullException(nameof(paymentCard.LastFourDigits), "Property is required for class PaymentCard.");
-
-            if (paymentCard.ExpirationMonthOption.IsSet && paymentCard.ExpirationMonth == null)
-                throw new ArgumentNullException(nameof(paymentCard.ExpirationMonth), "Property is required for class PaymentCard.");
-
-            if (paymentCard.ExpirationYearOption.IsSet && paymentCard.ExpirationYear == null)
-                throw new ArgumentNullException(nameof(paymentCard.ExpirationYear), "Property is required for class PaymentCard.");
 
             writer.WriteString("amount", paymentCard.Amount);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/ProcessCfarPaymentRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/ProcessCfarPaymentRequest.cs
@@ -334,24 +334,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (emailAddress.IsSet && emailAddress.Value == null)
                 throw new ArgumentNullException(nameof(emailAddress), "Property is not nullable for class ProcessCfarPaymentRequest.");
 
-            if (addressLine1.IsSet && addressLine1.Value == null)
-                throw new ArgumentNullException(nameof(addressLine1), "Property is not nullable for class ProcessCfarPaymentRequest.");
-
-            if (addressLine2.IsSet && addressLine2.Value == null)
-                throw new ArgumentNullException(nameof(addressLine2), "Property is not nullable for class ProcessCfarPaymentRequest.");
-
-            if (city.IsSet && city.Value == null)
-                throw new ArgumentNullException(nameof(city), "Property is not nullable for class ProcessCfarPaymentRequest.");
-
-            if (stateOrProvince.IsSet && stateOrProvince.Value == null)
-                throw new ArgumentNullException(nameof(stateOrProvince), "Property is not nullable for class ProcessCfarPaymentRequest.");
-
-            if (postalCode.IsSet && postalCode.Value == null)
-                throw new ArgumentNullException(nameof(postalCode), "Property is not nullable for class ProcessCfarPaymentRequest.");
-
-            if (country.IsSet && country.Value == null)
-                throw new ArgumentNullException(nameof(country), "Property is not nullable for class ProcessCfarPaymentRequest.");
-
             return new ProcessCfarPaymentRequest(paymentMethodToken.Value!, firstName.Value!, lastName.Value!, pnrReference.Value!, emailAddress.Value!, addressLine1, addressLine2, city, stateOrProvince, postalCode, country);
         }
 
@@ -393,24 +375,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (processCfarPaymentRequest.EmailAddress == null)
                 throw new ArgumentNullException(nameof(processCfarPaymentRequest.EmailAddress), "Property is required for class ProcessCfarPaymentRequest.");
-
-            if (processCfarPaymentRequest.AddressLine1Option.IsSet && processCfarPaymentRequest.AddressLine1 == null)
-                throw new ArgumentNullException(nameof(processCfarPaymentRequest.AddressLine1), "Property is required for class ProcessCfarPaymentRequest.");
-
-            if (processCfarPaymentRequest.AddressLine2Option.IsSet && processCfarPaymentRequest.AddressLine2 == null)
-                throw new ArgumentNullException(nameof(processCfarPaymentRequest.AddressLine2), "Property is required for class ProcessCfarPaymentRequest.");
-
-            if (processCfarPaymentRequest.CityOption.IsSet && processCfarPaymentRequest.City == null)
-                throw new ArgumentNullException(nameof(processCfarPaymentRequest.City), "Property is required for class ProcessCfarPaymentRequest.");
-
-            if (processCfarPaymentRequest.StateOrProvinceOption.IsSet && processCfarPaymentRequest.StateOrProvince == null)
-                throw new ArgumentNullException(nameof(processCfarPaymentRequest.StateOrProvince), "Property is required for class ProcessCfarPaymentRequest.");
-
-            if (processCfarPaymentRequest.PostalCodeOption.IsSet && processCfarPaymentRequest.PostalCode == null)
-                throw new ArgumentNullException(nameof(processCfarPaymentRequest.PostalCode), "Property is required for class ProcessCfarPaymentRequest.");
-
-            if (processCfarPaymentRequest.CountryOption.IsSet && processCfarPaymentRequest.Country == null)
-                throw new ArgumentNullException(nameof(processCfarPaymentRequest.Country), "Property is required for class ProcessCfarPaymentRequest.");
 
             writer.WriteString("payment_method_token", processCfarPaymentRequest.PaymentMethodToken);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/ProcessDgPaymentRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/ProcessDgPaymentRequest.cs
@@ -357,30 +357,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (phoneNumber.IsSet && phoneNumber.Value == null)
                 throw new ArgumentNullException(nameof(phoneNumber), "Property is not nullable for class ProcessDgPaymentRequest.");
 
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (addressLine1.IsSet && addressLine1.Value == null)
-                throw new ArgumentNullException(nameof(addressLine1), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (addressLine2.IsSet && addressLine2.Value == null)
-                throw new ArgumentNullException(nameof(addressLine2), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (city.IsSet && city.Value == null)
-                throw new ArgumentNullException(nameof(city), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (stateOrProvince.IsSet && stateOrProvince.Value == null)
-                throw new ArgumentNullException(nameof(stateOrProvince), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (postalCode.IsSet && postalCode.Value == null)
-                throw new ArgumentNullException(nameof(postalCode), "Property is not nullable for class ProcessDgPaymentRequest.");
-
-            if (country.IsSet && country.Value == null)
-                throw new ArgumentNullException(nameof(country), "Property is not nullable for class ProcessDgPaymentRequest.");
-
             return new ProcessDgPaymentRequest(paymentToken.Value!, pnrReference.Value!, emailAddress.Value!, phoneNumber.Value!, firstName, lastName, addressLine1, addressLine2, city, stateOrProvince, postalCode, country);
         }
 
@@ -419,30 +395,6 @@ namespace Com.Hopper.Hts.Airlines.Model
 
             if (processDgPaymentRequest.PhoneNumber == null)
                 throw new ArgumentNullException(nameof(processDgPaymentRequest.PhoneNumber), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.FirstNameOption.IsSet && processDgPaymentRequest.FirstName == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.FirstName), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.LastNameOption.IsSet && processDgPaymentRequest.LastName == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.LastName), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.AddressLine1Option.IsSet && processDgPaymentRequest.AddressLine1 == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.AddressLine1), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.AddressLine2Option.IsSet && processDgPaymentRequest.AddressLine2 == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.AddressLine2), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.CityOption.IsSet && processDgPaymentRequest.City == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.City), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.StateOrProvinceOption.IsSet && processDgPaymentRequest.StateOrProvince == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.StateOrProvince), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.PostalCodeOption.IsSet && processDgPaymentRequest.PostalCode == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.PostalCode), "Property is required for class ProcessDgPaymentRequest.");
-
-            if (processDgPaymentRequest.CountryOption.IsSet && processDgPaymentRequest.Country == null)
-                throw new ArgumentNullException(nameof(processDgPaymentRequest.Country), "Property is required for class ProcessDgPaymentRequest.");
 
             writer.WriteString("payment_token", processDgPaymentRequest.PaymentToken);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Safari.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Safari.cs
@@ -190,9 +190,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Safari.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Safari.");
-
             return new Safari(type.Value!.Value!, varVersion);
         }
 
@@ -220,9 +217,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Safari safari, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (safari.VarVersionOption.IsSet && safari.VarVersion == null)
-                throw new ArgumentNullException(nameof(safari.VarVersion), "Property is required for class Safari.");
-
             var typeRawValue = Safari.TypeEnumToJsonValue(safari.Type);
             writer.WriteString("type", typeRawValue);
             if (safari.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/Tablet.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Tablet.cs
@@ -253,15 +253,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Tablet.");
 
-            if (platform.IsSet && platform.Value == null)
-                throw new ArgumentNullException(nameof(platform), "Property is not nullable for class Tablet.");
-
-            if (uiTheme.IsSet && uiTheme.Value == null)
-                throw new ArgumentNullException(nameof(uiTheme), "Property is not nullable for class Tablet.");
-
-            if (releaseBuild.IsSet && releaseBuild.Value == null)
-                throw new ArgumentNullException(nameof(releaseBuild), "Property is not nullable for class Tablet.");
-
             return new Tablet(id.Value!, type.Value!.Value!, platform, uiTheme, releaseBuild);
         }
 
@@ -291,15 +282,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (tablet.Id == null)
                 throw new ArgumentNullException(nameof(tablet.Id), "Property is required for class Tablet.");
-
-            if (tablet.PlatformOption.IsSet && tablet.Platform == null)
-                throw new ArgumentNullException(nameof(tablet.Platform), "Property is required for class Tablet.");
-
-            if (tablet.UiThemeOption.IsSet && tablet.UiTheme == null)
-                throw new ArgumentNullException(nameof(tablet.UiTheme), "Property is required for class Tablet.");
-
-            if (tablet.ReleaseBuildOption.IsSet && tablet.ReleaseBuild == null)
-                throw new ArgumentNullException(nameof(tablet.ReleaseBuild), "Property is required for class Tablet.");
 
             writer.WriteString("id", tablet.Id);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/UpdateCfarContractItinerarySlicesRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/UpdateCfarContractItinerarySlicesRequest.cs
@@ -162,12 +162,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (slices.IsSet && slices.Value == null)
                 throw new ArgumentNullException(nameof(slices), "Property is not nullable for class UpdateCfarContractItinerarySlicesRequest.");
 
-            if (passengerCounts.IsSet && passengerCounts.Value == null)
-                throw new ArgumentNullException(nameof(passengerCounts), "Property is not nullable for class UpdateCfarContractItinerarySlicesRequest.");
-
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class UpdateCfarContractItinerarySlicesRequest.");
-
             return new UpdateCfarContractItinerarySlicesRequest(slices.Value!, passengerCounts, pnrReference);
         }
 
@@ -197,12 +191,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         {
             if (updateCfarContractItinerarySlicesRequest.Slices == null)
                 throw new ArgumentNullException(nameof(updateCfarContractItinerarySlicesRequest.Slices), "Property is required for class UpdateCfarContractItinerarySlicesRequest.");
-
-            if (updateCfarContractItinerarySlicesRequest.PassengerCountsOption.IsSet && updateCfarContractItinerarySlicesRequest.PassengerCounts == null)
-                throw new ArgumentNullException(nameof(updateCfarContractItinerarySlicesRequest.PassengerCounts), "Property is required for class UpdateCfarContractItinerarySlicesRequest.");
-
-            if (updateCfarContractItinerarySlicesRequest.PnrReferenceOption.IsSet && updateCfarContractItinerarySlicesRequest.PnrReference == null)
-                throw new ArgumentNullException(nameof(updateCfarContractItinerarySlicesRequest.PnrReference), "Property is required for class UpdateCfarContractItinerarySlicesRequest.");
 
             writer.WritePropertyName("slices");
             JsonSerializer.Serialize(writer, updateCfarContractItinerarySlicesRequest.Slices, jsonSerializerOptions);

--- a/src/Com.Hopper.Hts.Airlines/Model/UpdateCfarContractRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/UpdateCfarContractRequest.cs
@@ -492,57 +492,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (status.IsSet && status.Value == null)
                 throw new ArgumentNullException(nameof(status), "Property is not nullable for class UpdateCfarContractRequest.");
 
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (emailAddress.IsSet && emailAddress.Value == null)
-                throw new ArgumentNullException(nameof(emailAddress), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (phoneNumber.IsSet && phoneNumber.Value == null)
-                throw new ArgumentNullException(nameof(phoneNumber), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (addressLine1.IsSet && addressLine1.Value == null)
-                throw new ArgumentNullException(nameof(addressLine1), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (addressLine2.IsSet && addressLine2.Value == null)
-                throw new ArgumentNullException(nameof(addressLine2), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (city.IsSet && city.Value == null)
-                throw new ArgumentNullException(nameof(city), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (stateOrProvince.IsSet && stateOrProvince.Value == null)
-                throw new ArgumentNullException(nameof(stateOrProvince), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (postalCode.IsSet && postalCode.Value == null)
-                throw new ArgumentNullException(nameof(postalCode), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (country.IsSet && country.Value == null)
-                throw new ArgumentNullException(nameof(country), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (taxesTotal.IsSet && taxesTotal.Value == null)
-                throw new ArgumentNullException(nameof(taxesTotal), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (currency.IsSet && currency.Value == null)
-                throw new ArgumentNullException(nameof(currency), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (exchangeRate.IsSet && exchangeRate.Value == null)
-                throw new ArgumentNullException(nameof(exchangeRate), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class UpdateCfarContractRequest.");
-
-            if (formsOfPayment.IsSet && formsOfPayment.Value == null)
-                throw new ArgumentNullException(nameof(formsOfPayment), "Property is not nullable for class UpdateCfarContractRequest.");
-
             return new UpdateCfarContractRequest(status.Value!.Value!, pnrReference, emailAddress, phoneNumber, firstName, lastName, addressLine1, addressLine2, city, stateOrProvince, postalCode, country, taxesTotal, taxes, currency, exchangeRate, totalPrice, formsOfPayment);
         }
 
@@ -570,57 +519,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, UpdateCfarContractRequest updateCfarContractRequest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (updateCfarContractRequest.PnrReferenceOption.IsSet && updateCfarContractRequest.PnrReference == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.PnrReference), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.EmailAddressOption.IsSet && updateCfarContractRequest.EmailAddress == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.EmailAddress), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.PhoneNumberOption.IsSet && updateCfarContractRequest.PhoneNumber == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.PhoneNumber), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.FirstNameOption.IsSet && updateCfarContractRequest.FirstName == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.FirstName), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.LastNameOption.IsSet && updateCfarContractRequest.LastName == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.LastName), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.AddressLine1Option.IsSet && updateCfarContractRequest.AddressLine1 == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.AddressLine1), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.AddressLine2Option.IsSet && updateCfarContractRequest.AddressLine2 == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.AddressLine2), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.CityOption.IsSet && updateCfarContractRequest.City == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.City), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.StateOrProvinceOption.IsSet && updateCfarContractRequest.StateOrProvince == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.StateOrProvince), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.PostalCodeOption.IsSet && updateCfarContractRequest.PostalCode == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.PostalCode), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.CountryOption.IsSet && updateCfarContractRequest.Country == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.Country), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.TaxesTotalOption.IsSet && updateCfarContractRequest.TaxesTotal == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.TaxesTotal), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.TaxesOption.IsSet && updateCfarContractRequest.Taxes == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.Taxes), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.CurrencyOption.IsSet && updateCfarContractRequest.Currency == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.Currency), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.ExchangeRateOption.IsSet && updateCfarContractRequest.ExchangeRate == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.ExchangeRate), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.TotalPriceOption.IsSet && updateCfarContractRequest.TotalPrice == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.TotalPrice), "Property is required for class UpdateCfarContractRequest.");
-
-            if (updateCfarContractRequest.FormsOfPaymentOption.IsSet && updateCfarContractRequest.FormsOfPayment == null)
-                throw new ArgumentNullException(nameof(updateCfarContractRequest.FormsOfPayment), "Property is required for class UpdateCfarContractRequest.");
-
             var statusRawValue = CfarStatusValueConverter.ToJsonValue(updateCfarContractRequest.Status);
             writer.WriteString("status", statusRawValue);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/UpdateDgContractStatusRequest.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/UpdateDgContractStatusRequest.cs
@@ -470,54 +470,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (status.IsSet && status.Value == null)
                 throw new ArgumentNullException(nameof(status), "Property is not nullable for class UpdateDgContractStatusRequest.");
 
-            if (pnrReference.IsSet && pnrReference.Value == null)
-                throw new ArgumentNullException(nameof(pnrReference), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (emailAddress.IsSet && emailAddress.Value == null)
-                throw new ArgumentNullException(nameof(emailAddress), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (phoneNumber.IsSet && phoneNumber.Value == null)
-                throw new ArgumentNullException(nameof(phoneNumber), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (firstName.IsSet && firstName.Value == null)
-                throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (lastName.IsSet && lastName.Value == null)
-                throw new ArgumentNullException(nameof(lastName), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (addressLine1.IsSet && addressLine1.Value == null)
-                throw new ArgumentNullException(nameof(addressLine1), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (addressLine2.IsSet && addressLine2.Value == null)
-                throw new ArgumentNullException(nameof(addressLine2), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (city.IsSet && city.Value == null)
-                throw new ArgumentNullException(nameof(city), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (stateOrProvince.IsSet && stateOrProvince.Value == null)
-                throw new ArgumentNullException(nameof(stateOrProvince), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (postalCode.IsSet && postalCode.Value == null)
-                throw new ArgumentNullException(nameof(postalCode), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (country.IsSet && country.Value == null)
-                throw new ArgumentNullException(nameof(country), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (taxesTotal.IsSet && taxesTotal.Value == null)
-                throw new ArgumentNullException(nameof(taxesTotal), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (taxes.IsSet && taxes.Value == null)
-                throw new ArgumentNullException(nameof(taxes), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (formsOfPayment.IsSet && formsOfPayment.Value == null)
-                throw new ArgumentNullException(nameof(formsOfPayment), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (totalPrice.IsSet && totalPrice.Value == null)
-                throw new ArgumentNullException(nameof(totalPrice), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
-            if (currency.IsSet && currency.Value == null)
-                throw new ArgumentNullException(nameof(currency), "Property is not nullable for class UpdateDgContractStatusRequest.");
-
             return new UpdateDgContractStatusRequest(status.Value!.Value!, pnrReference, emailAddress, phoneNumber, firstName, lastName, addressLine1, addressLine2, city, stateOrProvince, postalCode, country, taxesTotal, taxes, formsOfPayment, totalPrice, currency);
         }
 
@@ -545,54 +497,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, UpdateDgContractStatusRequest updateDgContractStatusRequest, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (updateDgContractStatusRequest.PnrReferenceOption.IsSet && updateDgContractStatusRequest.PnrReference == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.PnrReference), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.EmailAddressOption.IsSet && updateDgContractStatusRequest.EmailAddress == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.EmailAddress), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.PhoneNumberOption.IsSet && updateDgContractStatusRequest.PhoneNumber == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.PhoneNumber), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.FirstNameOption.IsSet && updateDgContractStatusRequest.FirstName == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.FirstName), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.LastNameOption.IsSet && updateDgContractStatusRequest.LastName == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.LastName), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.AddressLine1Option.IsSet && updateDgContractStatusRequest.AddressLine1 == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.AddressLine1), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.AddressLine2Option.IsSet && updateDgContractStatusRequest.AddressLine2 == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.AddressLine2), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.CityOption.IsSet && updateDgContractStatusRequest.City == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.City), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.StateOrProvinceOption.IsSet && updateDgContractStatusRequest.StateOrProvince == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.StateOrProvince), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.PostalCodeOption.IsSet && updateDgContractStatusRequest.PostalCode == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.PostalCode), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.CountryOption.IsSet && updateDgContractStatusRequest.Country == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.Country), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.TaxesTotalOption.IsSet && updateDgContractStatusRequest.TaxesTotal == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.TaxesTotal), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.TaxesOption.IsSet && updateDgContractStatusRequest.Taxes == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.Taxes), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.FormsOfPaymentOption.IsSet && updateDgContractStatusRequest.FormsOfPayment == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.FormsOfPayment), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.TotalPriceOption.IsSet && updateDgContractStatusRequest.TotalPrice == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.TotalPrice), "Property is required for class UpdateDgContractStatusRequest.");
-
-            if (updateDgContractStatusRequest.CurrencyOption.IsSet && updateDgContractStatusRequest.Currency == null)
-                throw new ArgumentNullException(nameof(updateDgContractStatusRequest.Currency), "Property is required for class UpdateDgContractStatusRequest.");
-
             var statusRawValue = DgStatusValueConverter.ToJsonValue(updateDgContractStatusRequest.Status);
             writer.WriteString("status", statusRawValue);
 

--- a/src/Com.Hopper.Hts.Airlines/Model/UserInfo.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/UserInfo.cs
@@ -169,12 +169,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (airlineUserId.IsSet && airlineUserId.Value == null)
                 throw new ArgumentNullException(nameof(airlineUserId), "Property is not nullable for class UserInfo.");
 
-            if (createdDateTime.IsSet && createdDateTime.Value == null)
-                throw new ArgumentNullException(nameof(createdDateTime), "Property is not nullable for class UserInfo.");
-
-            if (previousBookings.IsSet && previousBookings.Value == null)
-                throw new ArgumentNullException(nameof(previousBookings), "Property is not nullable for class UserInfo.");
-
             return new UserInfo(airlineUserId.Value!, createdDateTime, previousBookings);
         }
 

--- a/src/Com.Hopper.Hts.Airlines/Model/Web.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Web.cs
@@ -213,12 +213,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Web.");
 
-            if (varOperatingSystem.IsSet && varOperatingSystem.Value == null)
-                throw new ArgumentNullException(nameof(varOperatingSystem), "Property is not nullable for class Web.");
-
-            if (browser.IsSet && browser.Value == null)
-                throw new ArgumentNullException(nameof(browser), "Property is not nullable for class Web.");
-
             return new Web(type.Value!.Value!, varOperatingSystem, browser);
         }
 
@@ -246,12 +240,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Web web, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (web.VarOperatingSystemOption.IsSet && web.VarOperatingSystem == null)
-                throw new ArgumentNullException(nameof(web.VarOperatingSystem), "Property is required for class Web.");
-
-            if (web.BrowserOption.IsSet && web.Browser == null)
-                throw new ArgumentNullException(nameof(web.Browser), "Property is required for class Web.");
-
             var typeRawValue = Web.TypeEnumToJsonValue(web.Type);
             writer.WriteString("type", typeRawValue);
             if (web.VarOperatingSystemOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/Model/Windows.cs
+++ b/src/Com.Hopper.Hts.Airlines/Model/Windows.cs
@@ -192,9 +192,6 @@ namespace Com.Hopper.Hts.Airlines.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Windows.");
 
-            if (varVersion.IsSet && varVersion.Value == null)
-                throw new ArgumentNullException(nameof(varVersion), "Property is not nullable for class Windows.");
-
             return new Windows(type.Value!.Value!, varVersion);
         }
 
@@ -222,9 +219,6 @@ namespace Com.Hopper.Hts.Airlines.Model
         /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, Windows windows, JsonSerializerOptions jsonSerializerOptions)
         {
-            if (windows.VarVersionOption.IsSet && windows.VarVersion == null)
-                throw new ArgumentNullException(nameof(windows.VarVersion), "Property is required for class Windows.");
-
             var typeRawValue = Windows.TypeEnumToJsonValue(windows.Type);
             writer.WriteString("type", typeRawValue);
             if (windows.VarVersionOption.IsSet)

--- a/src/Com.Hopper.Hts.Airlines/README.md
+++ b/src/Com.Hopper.Hts.Airlines/README.md
@@ -10,7 +10,7 @@ $properties = @(
     'validatable=false',
     'nullableReferenceTypes=true',
     'hideGenerationTimestamp=true',
-    'packageVersion=0.1.16',
+    'packageVersion=0.1.17',
     'packageAuthors=OpenAPI',
     'packageCompany=OpenAPI',
     'packageCopyright=No Copyright',
@@ -133,7 +133,7 @@ Authentication schemes defined for the API:
 
 
 ## Build
-- SDK version: 0.1.16
+- SDK version: 0.1.17
 - Generator version: 7.10.0
 - Build package: org.openapitools.codegen.languages.CSharpClientCodegen
 
@@ -177,11 +177,11 @@ Authentication schemes defined for the API:
 - packageCompany: OpenAPI
 - packageCopyright: No Copyright
 - packageDescription: A library generated from a OpenAPI doc
-- packageGuid: {48E9A5D3-6295-4012-AB0B-D54773FFFA1D}
+- packageGuid: {F0278D69-0DD8-4287-92FA-1CC74C654505}
 - packageName: Com.Hopper.Hts.Airlines
 - packageTags: 
 - packageTitle: OpenAPI Library
-- packageVersion: 0.1.16
+- packageVersion: 0.1.17
 - releaseNote: Minor update
 - returnICollection: false
 - sortParamsByRequiredFlag: 

--- a/templates/libraries/generichost/JsonConverter.mustache
+++ b/templates/libraries/generichost/JsonConverter.mustache
@@ -281,11 +281,13 @@
             {{/required}}
             {{/allVars}}
             {{#allVars}}
+            {{#required}}
             {{^isNullable}}
             if ({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}.IsSet && {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}.Value == null)
                 throw new ArgumentNullException(nameof({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}), "Property is not nullable for class {{classname}}.");
 
             {{/isNullable}}
+            {{/required}}
             {{/allVars}}
             {{^vendorExtensions.x-duplicated-data-type}}
             {{#model.discriminator}}
@@ -426,13 +428,15 @@
             {{#lambda.trimLineBreaks}}
             {{#allVars}}
             {{^isDiscriminator}}
+            {{#required}}
             {{^isNullable}}
             {{#vendorExtensions.x-is-reference-type}}
-            if ({{^required}}{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}Option.IsSet && {{/required}}{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)
+            if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} == null)
                 throw new ArgumentNullException(nameof({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}), "Property is required for class {{classname}}.");
 
             {{/vendorExtensions.x-is-reference-type}}
             {{/isNullable}}
+            {{/required}}
             {{/isDiscriminator}}
             {{/allVars}}
             {{#allVars}}


### PR DESCRIPTION
Update JsonConverter template to only generate null-guards for required properties. Optional fields like release_build and ui_theme now accept null values, matching the API's actual behavior. Regenerated all models.

Added tests verifying nested type discriminators (device, platform, operating_system) serialize correctly and release_build nullable behavior.